### PR TITLE
feat: load candle dir from config or env

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,1 +1,4 @@
-{}
+{
+  "data_dir": "candle_data",
+  "pairs": []
+}


### PR DESCRIPTION
## Summary
- load candle data directory from `CANDLE_DATA_DIR` env var or `config.json`
- resolve default data directory via `std::filesystem` with OS-specific home
- add `data_dir` field to configuration

## Testing
- `g++ -std=c++20 -c src/core/candle_manager.cpp -Isrc/core -Iinclude`


------
https://chatgpt.com/codex/tasks/task_e_689659e1cfe483279e3bba14a7b4ce43