### PR TITLE
Implement candle utilities and signal calculations

### DIFF
--- a/src/candle_manager.cpp
+++ b/src/candle_manager.cpp
@@ -1,0 +1,167 @@
+#include "core/candle_manager.h"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#include <cstdlib>
+#include <nlohmann/json.hpp>
+
+namespace Core {
+
+namespace {
+
+std::filesystem::path resolve_data_dir() {
+    if (const char* env_dir = std::getenv("CANDLE_DATA_DIR")) {
+        return std::filesystem::path(env_dir);
+    }
+
+    std::ifstream cfg("config.json");
+    if (cfg.is_open()) {
+        try {
+            nlohmann::json j;
+            cfg >> j;
+            if (j.contains("data_dir") && j["data_dir"].is_string()) {
+                return std::filesystem::path(j["data_dir"].get<std::string>());
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to parse config.json: " << e.what() << std::endl;
+        }
+    }
+
+    const char* home = nullptr;
+#ifdef _WIN32
+    home = std::getenv("USERPROFILE");
+#else
+    home = std::getenv("HOME");
+#endif
+    if (home) {
+        return std::filesystem::path(home) / "candle_data";
+    }
+    return std::filesystem::current_path() / "candle_data";
+}
+
+const std::filesystem::path DATA_DIR = resolve_data_dir();
+
+} // namespace
+
+std::filesystem::path CandleManager::get_candle_path(const std::string& symbol, const std::string& interval) {
+    std::filesystem::create_directories(DATA_DIR); // Ensure directory exists
+    std::string filename = symbol + "_" + interval + ".csv";
+    return DATA_DIR / filename;
+}
+
+bool CandleManager::save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) {
+    std::filesystem::path path_to_save = get_candle_path(symbol, interval);
+    std::ofstream file(path_to_save);
+
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file for writing: " << path_to_save << std::endl;
+        return false;
+    }
+
+    // Write header
+    file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore\n";
+
+    // Write candle data
+    for (const auto& candle : candles) {
+        file << candle.open_time << ","
+             << std::fixed << std::setprecision(8) << candle.open << ","
+             << std::fixed << std::setprecision(8) << candle.high << ","
+             << std::fixed << std::setprecision(8) << candle.low << ","
+             << std::fixed << std::setprecision(8) << candle.close << ","
+             << std::fixed << std::setprecision(8) << candle.volume << ","
+             << candle.close_time << ","
+             << std::fixed << std::setprecision(8) << candle.quote_asset_volume << ","
+             << candle.number_of_trades << ","
+             << std::fixed << std::setprecision(8) << candle.taker_buy_base_asset_volume << ","
+             << std::fixed << std::setprecision(8) << candle.taker_buy_quote_asset_volume << ","
+             << std::fixed << std::setprecision(8) << candle.ignore << "\n";
+    }
+
+    file.close();
+    return true;
+}
+
+std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const std::string& interval) {
+    std::filesystem::path path = get_candle_path(symbol, interval);
+    std::vector<Candle> candles;
+
+    if (!std::filesystem::exists(path)) {
+        // std::cerr << "Warning: Candle file not found: " << path << std::endl;
+        return candles; // Return empty vector if file doesn't exist
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file for reading: " << path << std::endl;
+        return candles;
+    }
+
+    std::string line;
+    std::getline(file, line); // Skip header
+
+    while (std::getline(file, line)) {
+        std::stringstream ss(line);
+        std::string segment;
+        std::vector<std::string> seglist;
+
+        while(std::getline(ss, segment, ',')) {
+            seglist.push_back(segment);
+        }
+
+        // Ensure we have enough segments for a full candle
+        if (seglist.size() == 12) {
+            try {
+                Candle candle;
+                candle.open_time = std::stoll(seglist[0]);
+                candle.open = std::stod(seglist[1]);
+                candle.high = std::stod(seglist[2]);
+                candle.low = std::stod(seglist[3]);
+                candle.close = std::stod(seglist[4]);
+                candle.volume = std::stod(seglist[5]);
+                candle.close_time = std::stoll(seglist[6]);
+                candle.quote_asset_volume = std::stod(seglist[7]);
+                candle.number_of_trades = std::stoi(seglist[8]);
+                candle.taker_buy_base_asset_volume = std::stod(seglist[9]);
+                candle.taker_buy_quote_asset_volume = std::stod(seglist[10]);
+                candle.ignore = std::stod(seglist[11]);
+                candles.push_back(candle);
+            } catch (const std::exception& e) {
+                std::cerr << "Error parsing candle line: " << line << " - " << e.what() << std::endl;
+            }
+        } else {
+            std::cerr << "Warning: Malformed candle line (expected 12 segments): " << line << std::endl;
+        }
+    }
+
+    file.close();
+    return candles;
+}
+
+std::vector<std::string> CandleManager::list_stored_data() {
+    std::vector<std::string> stored_files;
+    if (std::filesystem::exists(DATA_DIR) && std::filesystem::is_directory(DATA_DIR)) {
+        for (const auto& entry : std::filesystem::directory_iterator(DATA_DIR)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".csv") {
+                std::string filename = entry.path().filename().string();
+                // Assuming filename format is SYMBOL_INTERVAL.csv
+                // Extract SYMBOL and INTERVAL
+                size_t last_underscore = filename.rfind('_');
+                size_t dot_csv = filename.rfind(".csv");
+                if (last_underscore != std::string::npos && dot_csv != std::string::npos && last_underscore < dot_csv) {
+                    std::string symbol = filename.substr(0, last_underscore);
+                    std::string interval = filename.substr(last_underscore + 1, dot_csv - (last_underscore + 1));
+                    std::cout << "Processing file: " << filename << ", Extracted: Symbol=" << symbol << ", Interval=" << interval << std::endl; // Debug print
+                    stored_files.push_back(symbol + " (" + interval + ")");
+                } else {
+                    std::cout << "Processing file: " << filename << ", Unknown format." << std::endl; // Debug print
+                    stored_files.push_back(filename + " (unknown format)");
+                }
+            }
+        }
+    }
+    return stored_files;
+}
+
+} // namespace Core
+

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -1,0 +1,44 @@
+#include "signal.h"
+#include <numeric>
+
+namespace Signal {
+
+double simple_moving_average(const std::vector<Core::Candle>& candles, std::size_t index, std::size_t period) {
+    if (period == 0 || index >= candles.size() || index + 1 < period) {
+        return 0.0;
+    }
+    std::size_t start = index + 1 - period;
+    double sum = 0.0;
+    for (std::size_t i = start; i <= index; ++i) {
+        sum += candles[i].close;
+    }
+    return sum / static_cast<double>(period);
+}
+
+int sma_crossover_signal(const std::vector<Core::Candle>& candles,
+                         std::size_t index,
+                         std::size_t short_period,
+                         std::size_t long_period) {
+    if (short_period == 0 || long_period == 0 || short_period >= long_period) {
+        return 0;
+    }
+    if (index >= candles.size() || index + 1 < long_period) {
+        return 0;
+    }
+
+    double short_prev = simple_moving_average(candles, index - 1, short_period);
+    double long_prev  = simple_moving_average(candles, index - 1, long_period);
+    double short_curr = simple_moving_average(candles, index, short_period);
+    double long_curr  = simple_moving_average(candles, index, long_period);
+
+    if (short_prev <= long_prev && short_curr > long_curr) {
+        return 1; // Bullish crossover
+    }
+    if (short_prev >= long_prev && short_curr < long_curr) {
+        return -1; // Bearish crossover
+    }
+    return 0;
+}
+
+} // namespace Signal
+

--- a/src/signal.h
+++ b/src/signal.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "core/candle.h"
+#include <vector>
+
+namespace Signal {
+
+// Calculates simple moving average of candle close prices.
+double simple_moving_average(const std::vector<Core::Candle>& candles, std::size_t index, std::size_t period);
+
+// Generates a trading signal based on SMA crossover.
+// Returns 1 when short SMA crosses above long SMA,
+// -1 when it crosses below, and 0 otherwise.
+int sma_crossover_signal(const std::vector<Core::Candle>& candles,
+                         std::size_t index,
+                         std::size_t short_period,
+                         std::size_t long_period);
+
+} // namespace Signal
+

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -1,0 +1,17 @@
+#include "core/candle_manager.h"
+#include <cassert>
+#include <vector>
+
+int main() {
+    using namespace Core;
+    std::vector<Candle> candles;
+    candles.emplace_back(1,1,1,1,1,1,1,1,1,1,1,0);
+    bool saved = CandleManager::save_candles("TEST","1m",candles);
+    assert(saved);
+    auto loaded = CandleManager::load_candles("TEST","1m");
+    assert(loaded.size() == 1);
+    assert(loaded[0].close == 1);
+    auto list = CandleManager::list_stored_data();
+    assert(!list.empty());
+    return 0;
+}

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -1,0 +1,20 @@
+#include "signal.h"
+#include <cassert>
+#include <vector>
+
+int main() {
+    std::vector<Core::Candle> candles;
+    double closes[] = {5,4,3,2,3,4};
+    for (int i = 0; i < 6; ++i) {
+        candles.emplace_back(i,0,0,0,closes[i],0,0,0,0,0,0,0);
+    }
+    int sig = Signal::sma_crossover_signal(candles,5,2,3);
+    assert(sig == 1);
+    candles.emplace_back(6,0,0,0,3,0,0,0,0,0,0,0);
+    candles.emplace_back(7,0,0,0,2,0,0,0,0,0,0,0);
+    sig = Signal::sma_crossover_signal(candles,7,2,3);
+    assert(sig == -1);
+    double sma = Signal::simple_moving_average(candles,7,3);
+    assert(static_cast<int>(sma) == 3); // average of 3,2,4? Wait index 7: candles[5]=4, candles[6]=3, candles[7]=2 => 3
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add full candle management implementation for saving, loading and listing cached candles
- introduce signal helpers with SMA and SMA crossover calculation
- add unit tests covering candle manager persistence and signal generation

## Testing
- `g++ -std=c++20 tests/test_signal.cpp src/signal.cpp -Isrc -Isrc/core -o tests/test_signal`
- `./tests/test_signal`
- `g++ -std=c++20 tests/test_candle_manager.cpp src/core/candle_manager.cpp -Isrc -Isrc/core -o tests/test_candle_manager`
- `mkdir -p tests/tmp_candles`
- `CANDLE_DATA_DIR=tests/tmp_candles ./tests/test_candle_manager`


------
https://chatgpt.com/codex/tasks/task_e_6896737d8ffc83279a2ea1f1151b9915