### PR TITLE
Add .gitignore for build and IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Ignore build directories and CMake artifacts
+build/
+CMakeFiles/
+CMakeCache.txt
+
+# Compiled object files
+*.o
+*.obj
+
+# Debug and program database files
+*.pdb
+*.idb
+
+# Visual Studio temporary files
+.vs/
+*.vcxproj.user
+*.vcproj.user
+*.suo
+*.user
+*.userosscache
+*.ncb
+*.log
+*.tlog
+*.cache
+
+# IDE settings
+.vscode/
+
+# Editor swap/backup files
+*~


### PR DESCRIPTION
## Summary
- ignore CMake build directories and generated files
- ignore object, PDB, and other Visual Studio IDE artifacts

## Testing
- `cmake -S . -B build_tmp` *(fails: Could not find package configuration file provided by "imgui"*)

------
https://chatgpt.com/codex/tasks/task_e_68967a05ec3083279da68a3394347d6b