### PR TITLE
Remove unused Arrow dependency and conditionally link DirectX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(imgui CONFIG REQUIRED)
 find_package(implot CONFIG REQUIRED)
 find_package(cpr CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(Arrow CONFIG REQUIRED)
 
 add_executable(TradingTerminal
     src/main.cpp
@@ -27,10 +26,11 @@ target_link_libraries(TradingTerminal PRIVATE
     implot::implot
     cpr::cpr
     nlohmann_json::nlohmann_json
-    arrow_shared
-    d3d11.lib
-    dxgi.lib
 )
+
+if (WIN32)
+    target_link_libraries(TradingTerminal PRIVATE d3d11 dxgi)
+endif()
 
 # Include directories if needed (vcpkg handles most of this automatically)
 target_include_directories(TradingTerminal PRIVATE

--- a/build/TradingTerminal.vcxproj
+++ b/build/TradingTerminal.vcxproj
@@ -131,7 +131,7 @@ exit /b %1
 if %errorlevel% neq 0 goto :VCEnd</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\debug\lib\imguid.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\implotd.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\arrow.lib;d3d11.lib;dxgi.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\debug\lib\imguid.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\implotd.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -191,7 +191,7 @@ exit /b %1
 if %errorlevel% neq 0 goto :VCEnd</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\arrow.lib;d3d11.lib;dxgi.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -251,7 +251,7 @@ exit /b %1
 if %errorlevel% neq 0 goto :VCEnd</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\arrow.lib;d3d11.lib;dxgi.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -310,7 +310,7 @@ exit /b %1
 if %errorlevel% neq 0 goto :VCEnd</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\arrow.lib;d3d11.lib;dxgi.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Users\User\vcpkg\installed\x64-windows\lib\imgui.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\implot.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\cpr.lib;C:\Users\User\vcpkg\installed\x64-windows\lib\libcurl.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
## Summary
- drop Arrow dependency and link libraries only when needed
- restrict DirectX linkage to Windows builds
- clean Visual Studio project of unused Arrow and DirectX libraries

## Testing
- `cmake -S . -B build_test` *(fails: Could not find a package configuration file provided by "imgui")*


------
https://chatgpt.com/codex/tasks/task_e_68967a06b9b483278915f22f8a56f4ce