### PR TITLE
Fetch and store candles for multiple intervals

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -8,7 +8,8 @@ namespace Core {
 
 std::vector<Candle> DataFetcher::fetch_klines(const std::string& symbol, const std::string& interval, int limit) {
     std::vector<Candle> candles;
-    std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol + "&interval=" + interval + "&limit=" + std::to_string(limit);
+    std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
+                       "&interval=" + interval + "&limit=" + std::to_string(limit);
     std::cout << "Fetching from URL: " << url << std::endl; // Debug print
 
     cpr::Response r = cpr::Get(cpr::Url{url});


### PR DESCRIPTION
## Summary
- Fetch and persist candles for several intervals in main using limit=5000
- Ensure DataFetcher builds request URL with configurable limit

## Testing
- `g++ -std=c++17 tests/test_candle_manager.cpp src/core/candle_manager.cpp -I src -I src/core -o /tmp/test_candle_manager && /tmp/test_candle_manager`
- `g++ -std=c++17 tests/test_signal.cpp src/signal.cpp -I src -I src/core -o /tmp/test_signal && /tmp/test_signal`


------
https://chatgpt.com/codex/tasks/task_e_6896fbce72ac8327aa7f18d3fc0214c7