### PR TITLE
Add candle append persistence

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -71,6 +71,22 @@ int main() {
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
 
+        static auto last_fetch = std::chrono::steady_clock::now();
+        auto now = std::chrono::steady_clock::now();
+        if (now - last_fetch >= std::chrono::minutes(1)) {
+            for (const auto& pair : selected_pairs) {
+                auto latest = DataFetcher::fetch_klines(pair, "1m", 1);
+                if (!latest.empty()) {
+                    auto& vec = all_candles[pair];
+                    if (vec.empty() || latest.back().open_time > vec.back().open_time) {
+                        vec.push_back(latest.back());
+                        CandleManager::append_candles(pair, "1m", {latest.back()});
+                    }
+                }
+            }
+            last_fetch = now;
+        }
+
         ImGui::Begin("Control Panel");
 
         ImGui::Text("Select pairs to load:");

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -12,6 +12,9 @@ public:
     // Saves a vector of candles to a CSV file.
     static bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
 
+    // Appends new candles to an existing CSV file, skipping duplicates.
+    static bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
+
     // Loads candles from a CSV file into a vector.
     static std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval);
 

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -1,9 +1,15 @@
 #include "core/candle_manager.h"
 #include <cassert>
 #include <vector>
+#include <filesystem>
+#include <cstdlib>
 
 int main() {
     using namespace Core;
+    std::filesystem::path test_dir = std::filesystem::temp_directory_path() / "candle_manager_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    setenv("CANDLE_DATA_DIR", test_dir.string().c_str(), 1);
     std::vector<Candle> candles;
     candles.emplace_back(1,1,1,1,1,1,1,1,1,1,1,0);
     bool saved = CandleManager::save_candles("TEST","1m",candles);
@@ -13,5 +19,19 @@ int main() {
     assert(loaded[0].close == 1);
     auto list = CandleManager::list_stored_data();
     assert(!list.empty());
+
+    std::vector<Candle> more;
+    more.emplace_back(2,2,2,2,2,2,2,2,2,2,2,0);
+    bool appended = CandleManager::append_candles("TEST","1m",more);
+    assert(appended);
+    loaded = CandleManager::load_candles("TEST","1m");
+    assert(loaded.size() == 2);
+    assert(loaded[1].open_time == 2);
+    bool appended_dup = CandleManager::append_candles("TEST","1m",more);
+    assert(appended_dup);
+    loaded = CandleManager::load_candles("TEST","1m");
+    assert(loaded.size() == 2); // no duplicates
+
+    std::filesystem::remove_all(test_dir);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `CandleManager::append_candles` to append new candle data without duplicates
- periodically fetch latest 1m candles in main loop and persist them via `append_candles`
- expand candle manager tests to cover append and dedupe behavior

## Testing
- `g++ -std=c++20 tests/test_candle_manager.cpp src/core/candle_manager.cpp -Iinclude -Isrc -o tests/test_candle_manager`
- `./tests/test_candle_manager`
- `g++ -std=c++20 tests/test_signal.cpp src/signal.cpp src/core/candle_manager.cpp src/core/data_fetcher.cpp src/candle.cpp -Iinclude -Isrc -o tests/test_signal` *(fails: cpr/cpr.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6897016a2bc483279677270f3b21ac6c