### PR TITLE
Enable custom pair input with validation and removal

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -79,9 +79,16 @@ int main() {
         ImGui::SameLine();
         if (ImGui::Button("Load Symbol")) {
             std::string symbol(new_symbol);
-            symbol.erase(std::remove(symbol.begin(), symbol.end(), '-'), symbol.end());
+            symbol.erase(
+                std::remove_if(symbol.begin(), symbol.end(),
+                               [](unsigned char c) { return std::isspace(c) || c == '-'; }),
+                symbol.end());
             std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
-            if (!symbol.empty() && std::find(selected_pairs.begin(), selected_pairs.end(), symbol) == selected_pairs.end()) {
+            bool valid = !symbol.empty() &&
+                         std::all_of(symbol.begin(), symbol.end(),
+                                     [](unsigned char c) { return std::isalnum(c); });
+            if (valid &&
+                std::find(selected_pairs.begin(), selected_pairs.end(), symbol) == selected_pairs.end()) {
                 selected_pairs.push_back(symbol);
                 Config::save_selected_pairs("config.json", selected_pairs);
             }
@@ -91,11 +98,16 @@ int main() {
         for (auto it = selected_pairs.begin(); it != selected_pairs.end();) {
             bool keep = true;
             if (ImGui::Checkbox(it->c_str(), &keep) && !keep) {
-                if (active_pair == *it && !selected_pairs.empty()) {
-                    active_pair = selected_pairs[0];
-                }
-                all_candles.erase(*it);
+                std::string removed = *it;
                 it = selected_pairs.erase(it);
+                all_candles.erase(removed);
+                if (active_pair == removed) {
+                    if (!selected_pairs.empty()) {
+                        active_pair = selected_pairs.front();
+                    } else {
+                        active_pair.clear();
+                    }
+                }
                 Config::save_selected_pairs("config.json", selected_pairs);
             } else {
                 ++it;


### PR DESCRIPTION
## Summary
- Allow arbitrary pair entry via ImGui input field and "Load Symbol" button
- Sanitize and validate symbols before storing
- Provide checkbox list of pairs with removal and active pair updates

## Testing
- `g++ -std=c++20 tests/test_candle_manager.cpp src/core/candle_manager.cpp src/candle.cpp src/config.cpp -Iinclude -Isrc -Isrc/core -o tests/test_candle_manager`
- `./tests/test_candle_manager`
- `g++ -std=c++20 tests/test_signal.cpp src/signal.cpp src/candle.cpp -Iinclude -Isrc -Isrc/core -o tests/test_signal`
- `./tests/test_signal`


------
https://chatgpt.com/codex/tasks/task_e_6897016b6e0c8327918db9bfce70da03