### PR TITLE
Use relative paths in build script

### DIFF
--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -1,7 +1,7 @@
 @echo off
-set PROJECT_DIR=C:\Users\User\trading_terminal_cpp
+set PROJECT_DIR=%~dp0
 set BUILD_DIR=%PROJECT_DIR%\build
-set VCPKG_TOOLCHAIN_FILE=C:\Users\User\vcpkg\scripts\buildsystems\vcpkg.cmake
+set VCPKG_TOOLCHAIN_FILE=%PROJECT_DIR%vcpkg\scripts\buildsystems\vcpkg.cmake
 
 echo Creating build directory if it doesn't exist...
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"


### PR DESCRIPTION
## Summary
- Derive project directory from the batch file location
- Look for vcpkg toolchain relative to the project directory

## Testing
- `bash build_and_run.bat` *(fails: build_and_run.bat: line 1: @echo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689704ee1a5c83278805b40467fe94a6