### PR TITLE
Improve backtester indices and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terminal_c
 
-Standalone C++ trading terminal using ImGui and other dependencies without requiring `vcpkg` or additional library installations.
+Standalone C++ trading terminal using ImGui and other dependencies. The project relies on packages provided by `vcpkg` and `find_package` in CMake.
 
 ## Состав
 
@@ -12,7 +12,7 @@ Standalone C++ trading terminal using ImGui and other dependencies without requi
   - ImPlot
   - CPR (встроен)
   - JSON (встроен)
-- `CMakeLists.txt` без `find_package()` и без `vcpkg`
+- `CMakeLists.txt` использует `find_package()` для зависимостей через `vcpkg`
 
 ## Инструкция
 
@@ -21,5 +21,18 @@ Standalone C++ trading terminal using ImGui and other dependencies without requi
 3. Нажми `Ctrl+Shift+B` для сборки
 4. Запусти `TradingTerminal.exe`
 
-📌 Не требует установки библиотек отдельно или подключения к интернету
+📌 Требуется установленный `vcpkg` и предварительная загрузка зависимостей
+
+## Сборка
+
+1. Установите [vcpkg](https://github.com/microsoft/vcpkg) и настройте переменную `CMAKE_TOOLCHAIN_FILE` на `scripts/buildsystems/vcpkg.cmake`.
+2. Выполните конфигурацию проекта:
+   ```
+   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+   ```
+3. Соберите проект:
+   ```
+   cmake --build build
+   ```
+4. Готовый исполняемый файл `TradingTerminal` (или `TradingTerminal.exe` на Windows) появится в каталоге `build`.
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,11 +8,7 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <thread>
 #include <chrono>
-#include <mutex>
-#include <condition_variable>
-#include <atomic>
 #include <algorithm>
 #include <cctype>
 
@@ -23,17 +19,6 @@
 using namespace Core;
 
 int main() {
-    std::atomic<bool> fetch_running{true};
-    std::mutex fetch_mutex;
-    std::condition_variable fetch_cv;
-
-    std::thread fetch_thread([&]() {
-        while (fetch_running) {
-            std::unique_lock<std::mutex> lock(fetch_mutex);
-            fetch_cv.wait_for(lock, std::chrono::seconds(1), [&] { return !fetch_running; });
-        }
-    });
-
     // Init GLFW
     if (!glfwInit()) return -1;
 
@@ -201,12 +186,6 @@ int main() {
         glClear(GL_COLOR_BUFFER_BIT);
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         glfwSwapBuffers(window);
-    }
-
-    fetch_running = false;
-    fetch_cv.notify_all();
-    if (fetch_thread.joinable()) {
-        fetch_thread.join();
     }
 
     // Cleanup

--- a/src/core/backtester.cpp
+++ b/src/core/backtester.cpp
@@ -10,6 +10,7 @@ BacktestResult Backtester::run() {
     BacktestResult result;
     bool in_position = false;
     double entry_price = 0.0;
+    size_t entry_index = 0;
     double total_pnl = 0.0;
     size_t wins = 0;
 
@@ -19,15 +20,17 @@ BacktestResult Backtester::run() {
             // enter long
             in_position = true;
             entry_price = m_candles[i].close;
+            entry_index = i;
         } else if (in_position && signal < 0) {
             // exit long
             double exit_price = m_candles[i].close;
             double pnl = exit_price - entry_price;
-            result.trades.push_back({i, i, entry_price, exit_price, pnl});
+            result.trades.push_back({entry_index, i, entry_price, exit_price, pnl});
             total_pnl += pnl;
             if (pnl > 0) ++wins;
             in_position = false;
             entry_price = 0.0;
+            entry_index = 0;
         }
 
         // mark-to-market equity

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -41,14 +41,22 @@ std::filesystem::path resolve_data_dir() {
     return std::filesystem::current_path() / "candle_data";
 }
 
-const std::filesystem::path DATA_DIR = resolve_data_dir();
+std::filesystem::path data_dir = resolve_data_dir();
 
 } // namespace
 
 std::filesystem::path CandleManager::get_candle_path(const std::string& symbol, const std::string& interval) {
-    std::filesystem::create_directories(DATA_DIR); // Ensure directory exists
+    std::filesystem::create_directories(data_dir); // Ensure directory exists
     std::string filename = symbol + "_" + interval + ".csv";
-    return DATA_DIR / filename;
+    return data_dir / filename;
+}
+
+void CandleManager::set_data_dir(const std::filesystem::path& dir) {
+    data_dir = dir;
+}
+
+std::filesystem::path CandleManager::get_data_dir() {
+    return data_dir;
 }
 
 bool CandleManager::save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) {
@@ -185,8 +193,8 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
 
 std::vector<std::string> CandleManager::list_stored_data() {
     std::vector<std::string> stored_files;
-    if (std::filesystem::exists(DATA_DIR) && std::filesystem::is_directory(DATA_DIR)) {
-        for (const auto& entry : std::filesystem::directory_iterator(DATA_DIR)) {
+    if (std::filesystem::exists(data_dir) && std::filesystem::is_directory(data_dir)) {
+        for (const auto& entry : std::filesystem::directory_iterator(data_dir)) {
             if (entry.is_regular_file() && entry.path().extension() == ".csv") {
                 std::string filename = entry.path().filename().string();
                 // Assuming filename format is SYMBOL_INTERVAL.csv
@@ -196,10 +204,8 @@ std::vector<std::string> CandleManager::list_stored_data() {
                 if (last_underscore != std::string::npos && dot_csv != std::string::npos && last_underscore < dot_csv) {
                     std::string symbol = filename.substr(0, last_underscore);
                     std::string interval = filename.substr(last_underscore + 1, dot_csv - (last_underscore + 1));
-                    std::cout << "Processing file: " << filename << ", Extracted: Symbol=" << symbol << ", Interval=" << interval << std::endl; // Debug print
                     stored_files.push_back(symbol + " (" + interval + ")");
                 } else {
-                    std::cout << "Processing file: " << filename << ", Unknown format." << std::endl; // Debug print
                     stored_files.push_back(filename + " (unknown format)");
                 }
             }

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -21,6 +21,10 @@ public:
     // Lists all locally stored candle data files (symbol_interval.csv).
     static std::vector<std::string> list_stored_data();
 
+    // Allows runtime configuration of the candle data directory
+    static void set_data_dir(const std::filesystem::path& dir);
+    static std::filesystem::path get_data_dir();
+
 private:
     // Helper function to get the full path for a candle CSV file.
     static std::filesystem::path get_candle_path(const std::string& symbol, const std::string& interval);

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -10,11 +10,7 @@ std::vector<Candle> DataFetcher::fetch_klines(const std::string& symbol, const s
     std::vector<Candle> candles;
     std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
                        "&interval=" + interval + "&limit=" + std::to_string(limit);
-    std::cout << "Fetching from URL: " << url << std::endl; // Debug print
-
     cpr::Response r = cpr::Get(cpr::Url{url});
-
-    std::cout << "HTTP Status Code: " << r.status_code << std::endl; // Debug print
 
     if (r.status_code == 200) {
         try {

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -9,7 +9,7 @@ int main() {
     std::filesystem::path test_dir = std::filesystem::temp_directory_path() / "candle_manager_test";
     std::filesystem::remove_all(test_dir);
     std::filesystem::create_directories(test_dir);
-    setenv("CANDLE_DATA_DIR", test_dir.string().c_str(), 1);
+    CandleManager::set_data_dir(test_dir);
     std::vector<Candle> candles;
     candles.emplace_back(1,1,1,1,1,1,1,1,1,1,1,0);
     bool saved = CandleManager::save_candles("TEST","1m",candles);


### PR DESCRIPTION
## Summary
- track correct entry/exit indices in backtester
- make candle data directory configurable at runtime and clean up debug prints
- remove unused fetch thread and document vcpkg-based build process

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "imgui")*
- `g++ -std=c++20 tests/test_candle_manager.cpp src/core/candle_manager.cpp src/candle.cpp src/config.cpp src/core/data_fetcher.cpp src/core/backtester.cpp src/signal.cpp -Iinclude -Isrc -o test_candle_manager` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689709c951d88327a32b8e8cac3f9b0a