### PR TITLE
Link ImGui backends and update setup script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(TradingTerminal
 # Link libraries to the executable
 target_link_libraries(TradingTerminal PRIVATE
     imgui::imgui
+    imgui::imgui_impl_glfw
+    imgui::imgui_impl_opengl3
     implot::implot
     cpr::cpr
     nlohmann_json::nlohmann_json

--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -23,7 +23,7 @@ if exist "%VCPKG_PATH%" (
 set TOOLCHAIN_FILE=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake
 
 echo Installing required packages...
-"%VCPKG_PATH%\vcpkg.exe" install imgui implot cpr nlohmann-json arrow glfw3 opengl
+"%VCPKG_PATH%\vcpkg.exe" install imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl
 
 set BUILD_DIR=%SCRIPT_DIR%build
 if exist "%BUILD_DIR%" (


### PR DESCRIPTION
## Summary
- Install ImGui with GLFW and OpenGL3 backend features via vcpkg
- Link ImGui backend targets for GLFW and OpenGL3 in the build

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "imgui")*

------
https://chatgpt.com/codex/tasks/task_e_68974fb1b7f4832787a91c2d64a2287f