### PR TITLE
Add ImPlot chart controls and crosshair

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -156,17 +156,69 @@ int main() {
         ImGui::End();
 
         ImGui::Begin("Chart");
-        if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), "Time", "Price")) {
-            const auto& candles = all_candles[active_pair];
-            std::vector<double> times, opens, highs, lows, closes;
-            for (const auto& c : candles) {
-                times.push_back((double)c.open_time / 1000.0);
-                opens.push_back(c.open);
-                highs.push_back(c.high);
-                lows.push_back(c.low);
-                closes.push_back(c.close);
-            }
 
+        const auto& candles = all_candles[active_pair];
+        std::vector<double> times, opens, highs, lows, closes;
+        for (const auto& c : candles) {
+            times.push_back((double)c.open_time / 1000.0);
+            opens.push_back(c.open);
+            highs.push_back(c.high);
+            lows.push_back(c.low);
+            closes.push_back(c.close);
+        }
+
+        static ImPlotRect manual_limits;
+        static bool use_manual_limits = false;
+
+        if (ImGui::Button("Zoom In")) {
+            double xc = (manual_limits.X.Min + manual_limits.X.Max) * 0.5;
+            double yc = (manual_limits.Y.Min + manual_limits.Y.Max) * 0.5;
+            double xr = (manual_limits.X.Max - manual_limits.X.Min) * 0.5;
+            double yr = (manual_limits.Y.Max - manual_limits.Y.Min) * 0.5;
+            manual_limits.X.Min = xc - xr * 0.5;
+            manual_limits.X.Max = xc + xr * 0.5;
+            manual_limits.Y.Min = yc - yr * 0.5;
+            manual_limits.Y.Max = yc + yr * 0.5;
+            use_manual_limits = true;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Zoom Out")) {
+            double xc = (manual_limits.X.Min + manual_limits.X.Max) * 0.5;
+            double yc = (manual_limits.Y.Min + manual_limits.Y.Max) * 0.5;
+            double xr = (manual_limits.X.Max - manual_limits.X.Min);
+            double yr = (manual_limits.Y.Max - manual_limits.Y.Min);
+            manual_limits.X.Min = xc - xr;
+            manual_limits.X.Max = xc + xr;
+            manual_limits.Y.Min = yc - yr;
+            manual_limits.Y.Max = yc + yr;
+            use_manual_limits = true;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Reset")) {
+            if (!times.empty()) {
+                manual_limits.X.Min = times.front();
+                manual_limits.X.Max = times.back();
+            }
+            if (!lows.empty() && !highs.empty()) {
+                manual_limits.Y.Min = *std::min_element(lows.begin(), lows.end());
+                manual_limits.Y.Max = *std::max_element(highs.begin(), highs.end());
+            }
+            use_manual_limits = true;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Fit")) {
+            ImPlot::FitNextPlotAxes();
+            use_manual_limits = false;
+        }
+
+        if (use_manual_limits) {
+            ImPlot::SetNextPlotLimits(manual_limits.X.Min, manual_limits.X.Max,
+                                     manual_limits.Y.Min, manual_limits.Y.Max,
+                                     ImGuiCond_Always);
+        }
+
+        ImPlotFlags plot_flags = ImPlotFlags_ContextMenu | ImPlotFlags_Crosshairs;
+        if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), "Time", "Price", plot_flags)) {
             Plot::PlotCandlestick(
                 "Candles",
                 times.data(), opens.data(), closes.data(), lows.data(), highs.data(),
@@ -175,7 +227,37 @@ int main() {
                 0.25f
             );
 
+            ImPlotRect cur_limits = ImPlot::GetPlotLimits();
+            if (!use_manual_limits) {
+                manual_limits = cur_limits;
+            }
+
+            static double cursor_x = 0.0;
+            static double cursor_y = 0.0;
+            if (ImPlot::IsPlotHovered()) {
+                ImPlotPoint mouse = ImPlot::GetPlotMousePos();
+                cursor_x = mouse.x;
+                cursor_y = mouse.y;
+            }
+
+            double vx[2] = {cursor_x, cursor_x};
+            double vy[2] = {cur_limits.Y.Min, cur_limits.Y.Max};
+            ImPlot::SetNextLineStyle(ImVec4(1,1,1,0.5f));
+            ImPlot::PlotLine("##vline", vx, vy, 2);
+
+            double hx[2] = {cur_limits.X.Min, cur_limits.X.Max};
+            double hy[2] = {cursor_y, cursor_y};
+            ImPlot::SetNextLineStyle(ImVec4(1,1,1,0.5f));
+            ImPlot::PlotLine("##hline", hx, hy, 2);
+
+            double price = closes.empty() ? 0.0 : closes.back();
+            double px[2] = {cur_limits.X.Min, cur_limits.X.Max};
+            double py[2] = {price, price};
+            ImPlot::SetNextLineStyle(ImVec4(0,1,0,1));
+            ImPlot::PlotLine("##price", px, py, 2);
+
             ImPlot::EndPlot();
+            ImPlot::ShowAltLegend();
         }
         ImGui::End();
 


### PR DESCRIPTION
## Summary
- Enable ImPlot context menu and crosshairs
- Add Zoom, Reset and Fit controls for chart
- Draw crosshair and current price line with alternative legend

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "imgui")*

------
https://chatgpt.com/codex/tasks/task_e_6897bdc1e9c8832787d91cb5c5f5051f