### PR TITLE
Add interval selection and per-interval candle storage

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,24 +44,20 @@ int main() {
     std::vector<std::string> selected_pairs = Config::load_selected_pairs("config.json");
     if (selected_pairs.empty()) selected_pairs.push_back("BTCUSDT");
     std::string active_pair = selected_pairs[0];
+    std::string active_interval = "1m";
 
-    // Load candles for several intervals
+    // Prepare candle storage by pair and interval
     const std::vector<std::string> intervals = {"1m", "5m", "15m", "1h", "4h", "1d"};
-    std::map<std::string, std::vector<Candle>> all_candles;
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> all_candles;
     for (const auto& pair : selected_pairs) {
-        for (const auto& interval : intervals) {
-            auto candles = CandleManager::load_candles(pair, interval);
-            if (candles.empty()) {
-                candles = DataFetcher::fetch_klines(pair, interval, 5000);
-                if (!candles.empty()) {
-                    CandleManager::save_candles(pair, interval, candles);
-                }
-            }
-            // keep 1m candles in memory for charting
-            if (interval == "1m") {
-                all_candles[pair] = candles;
+        auto candles = CandleManager::load_candles(pair, active_interval);
+        if (candles.empty()) {
+            candles = DataFetcher::fetch_klines(pair, active_interval, 5000);
+            if (!candles.empty()) {
+                CandleManager::save_candles(pair, active_interval, candles);
             }
         }
+        all_candles[pair][active_interval] = candles;
     }
 
     // Main loop
@@ -77,7 +73,7 @@ int main() {
             for (const auto& pair : selected_pairs) {
                 auto latest = DataFetcher::fetch_klines(pair, "1m", 1);
                 if (!latest.empty()) {
-                    auto& vec = all_candles[pair];
+                    auto& vec = all_candles[pair]["1m"];
                     if (vec.empty() || latest.back().open_time > vec.back().open_time) {
                         vec.push_back(latest.back());
                         CandleManager::append_candles(pair, "1m", {latest.back()});
@@ -136,19 +132,33 @@ int main() {
         for (const auto& pair : selected_pairs) {
             if (ImGui::RadioButton(pair.c_str(), active_pair == pair)) {
                 active_pair = pair;
-                if (all_candles.find(pair) == all_candles.end()) {
-                    for (const auto& interval : intervals) {
-                        auto candles = CandleManager::load_candles(pair, interval);
-                        if (candles.empty()) {
-                            candles = DataFetcher::fetch_klines(pair, interval, 5000);
-                            if (!candles.empty()) {
-                                CandleManager::save_candles(pair, interval, candles);
-                            }
-                        }
-                        if (interval == "1m") {
-                            all_candles[pair] = candles;
+                if (all_candles[pair][active_interval].empty()) {
+                    auto candles = CandleManager::load_candles(pair, active_interval);
+                    if (candles.empty()) {
+                        candles = DataFetcher::fetch_klines(pair, active_interval, 5000);
+                        if (!candles.empty()) {
+                            CandleManager::save_candles(pair, active_interval, candles);
                         }
                     }
+                    all_candles[pair][active_interval] = candles;
+                }
+            }
+        }
+
+        ImGui::Separator();
+        ImGui::Text("Interval:");
+        for (const auto& interval : intervals) {
+            if (ImGui::RadioButton(interval.c_str(), active_interval == interval)) {
+                active_interval = interval;
+                if (all_candles[active_pair][interval].empty()) {
+                    auto candles = CandleManager::load_candles(active_pair, interval);
+                    if (candles.empty()) {
+                        candles = DataFetcher::fetch_klines(active_pair, interval, 5000);
+                        if (!candles.empty()) {
+                            CandleManager::save_candles(active_pair, interval, candles);
+                        }
+                    }
+                    all_candles[active_pair][interval] = candles;
                 }
             }
         }
@@ -156,8 +166,8 @@ int main() {
         ImGui::End();
 
         ImGui::Begin("Chart");
-        if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), "Time", "Price")) {
-            const auto& candles = all_candles[active_pair];
+        if (ImPlot::BeginPlot(("Candles - " + active_pair + " [" + active_interval + "]").c_str(), "Time", "Price")) {
+            const auto& candles = all_candles[active_pair][active_interval];
             std::vector<double> times, opens, highs, lows, closes;
             for (const auto& c : candles) {
                 times.push_back((double)c.open_time / 1000.0);


### PR DESCRIPTION
## Summary
- Store candles by trading pair and timeframe with nested maps and track active interval
- Add Control Panel UI to select chart interval and lazy-load missing data
- Draw charts using candles for the chosen pair and interval

## Testing
- `g++ tests/test_signal.cpp src/signal.cpp -I src -std=c++20 -o test_signal && ./test_signal`
- `g++ tests/test_candle_manager.cpp src/core/candle_manager.cpp src/candle.cpp -I src -std=c++20 -larrow -o test_candle_manager && ./test_candle_manager` *(fails: nlohmann/json.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897bdbffeb883279fcba8bcdb94e131