### PR TITLE
Rename backtest window to distinguish from analytics window

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -376,8 +376,8 @@ int main() {
         }
         ImGui::End();
 
-        // Analytics Window
-        ImGui::Begin("Analytics");
+        // Backtest Window
+        ImGui::Begin("Backtest");
         static int short_p = 9;
         static int long_p = 21;
         ImGui::InputInt("Short SMA", &short_p);


### PR DESCRIPTION
## Summary
- Rename second ImGui window from "Analytics" to "Backtest" for clarity

## Testing
- `g++ -std=c++20 tests/test_signal.cpp src/signal.cpp src/candle.cpp -Isrc -o test_signal && ./test_signal`
- `g++ -std=c++20 tests/test_journal.cpp src/journal.cpp -Isrc -o test_journal && ./test_journal`
- `g++ -std=c++20 tests/test_candle_manager.cpp src/core/candle_manager.cpp src/candle.cpp -Isrc -o test_candle_manager && ./test_candle_manager`


------
https://chatgpt.com/codex/tasks/task_e_6897cd2ad6908327a7120c4cf884df63