### PR TITLE
Use enum for journal trade side

### DIFF
--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -18,7 +18,7 @@ bool Journal::load_json(const std::string& filename) {
     for (const auto& item : j) {
         Entry e;
         e.symbol = item.value("symbol", "");
-        e.side = item.value("side", "");
+        e.side = side_from_string(item.value("side", "BUY"));
         e.price = item.value("price", 0.0);
         e.quantity = item.value("quantity", 0.0);
         e.timestamp = item.value("timestamp", 0LL);
@@ -32,7 +32,7 @@ bool Journal::save_json(const std::string& filename) const {
     if (!f.is_open()) return false;
     nlohmann::json j = nlohmann::json::array();
     for (const auto& e : m_entries) {
-        j.push_back({{"symbol", e.symbol}, {"side", e.side}, {"price", e.price}, {"quantity", e.quantity}, {"timestamp", e.timestamp}});
+        j.push_back({{"symbol", e.symbol}, {"side", side_to_string(e.side)}, {"price", e.price}, {"quantity", e.quantity}, {"timestamp", e.timestamp}});
     }
     f << j.dump(4);
     return true;
@@ -49,7 +49,8 @@ bool Journal::load_csv(const std::string& filename) {
         Entry e;
         std::string field;
         std::getline(ss, e.symbol, ',');
-        std::getline(ss, e.side, ',');
+        std::getline(ss, field, ',');
+        e.side = side_from_string(field);
         std::getline(ss, field, ',');
         e.price = std::stod(field);
         std::getline(ss, field, ',');
@@ -65,7 +66,7 @@ bool Journal::save_csv(const std::string& filename) const {
     std::ofstream f(filename);
     if (!f.is_open()) return false;
     for (const auto& e : m_entries) {
-        f << e.symbol << ',' << e.side << ',' << e.price << ',' << e.quantity << ',' << e.timestamp << '\n';
+        f << e.symbol << ',' << side_to_string(e.side) << ',' << e.price << ',' << e.quantity << ',' << e.timestamp << '\n';
     }
     return true;
 }

--- a/src/journal.h
+++ b/src/journal.h
@@ -6,9 +6,19 @@
 
 namespace Journal {
 
+enum class Side { Buy, Sell };
+
+inline const char* side_to_string(Side s) {
+    return s == Side::Buy ? "BUY" : "SELL";
+}
+
+inline Side side_from_string(const std::string& s) {
+    return s == "SELL" ? Side::Sell : Side::Buy;
+}
+
 struct Entry {
     std::string symbol;
-    std::string side; // "BUY" or "SELL"
+    Side side = Side::Buy;
     double price = 0.0;
     double quantity = 0.0;
     std::int64_t timestamp = 0; // milliseconds since epoch

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -135,7 +135,7 @@ void DrawChartWindow(
         for (const auto& e : journal.entries()) {
             if (e.symbol == active_pair) {
                 double t = (double)e.timestamp / 1000.0;
-                if (e.side == "BUY") { jb_times.push_back(t); jb_prices.push_back(e.price); }
+                if (e.side == Journal::Side::Buy) { jb_times.push_back(t); jb_prices.push_back(e.price); }
                 else { js_times.push_back(t); js_prices.push_back(e.price); }
             }
         }

--- a/src/ui/journal_window.cpp
+++ b/src/ui/journal_window.cpp
@@ -17,7 +17,7 @@ void DrawJournalWindow(Journal::Journal& journal) {
     if (ImGui::Button("Add Trade")) {
         Journal::Entry e;
         e.symbol = j_symbol;
-        e.side = j_side == 0 ? "BUY" : "SELL";
+        e.side = j_side == 0 ? Journal::Side::Buy : Journal::Side::Sell;
         e.price = j_price;
         e.quantity = j_qty;
         e.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -42,7 +42,7 @@ void DrawJournalWindow(Journal::Journal& journal) {
         for (const auto& e : journal.entries()) {
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0); ImGui::Text("%s", e.symbol.c_str());
-            ImGui::TableSetColumnIndex(1); ImGui::Text("%s", e.side.c_str());
+            ImGui::TableSetColumnIndex(1); ImGui::Text("%s", Journal::side_to_string(e.side));
             ImGui::TableSetColumnIndex(2); ImGui::Text("%.2f", e.price);
             ImGui::TableSetColumnIndex(3); ImGui::Text("%.4f", e.quantity);
             ImGui::TableSetColumnIndex(4); ImGui::Text("%lld", (long long)e.timestamp);

--- a/tests/test_journal.cpp
+++ b/tests/test_journal.cpp
@@ -3,9 +3,14 @@
 #include <filesystem>
 
 int main() {
+    assert(std::string(Journal::side_to_string(Journal::Side::Buy)) == "BUY");
+    assert(Journal::side_from_string("SELL") == Journal::Side::Sell);
+
     Journal::Journal j;
-    Journal::Entry e{"BTC", "BUY", 100.0, 1.5, 1000};
-    j.add_entry(e);
+    Journal::Entry e1{"BTC", Journal::Side::Buy, 100.0, 1.5, 1000};
+    Journal::Entry e2{"ETH", Journal::Side::Sell, 200.0, 2.0, 2000};
+    j.add_entry(e1);
+    j.add_entry(e2);
     std::filesystem::path dir = std::filesystem::temp_directory_path() / "journal_test";
     std::filesystem::create_directories(dir);
     auto json_file = (dir / "journal.json").string();
@@ -16,13 +21,16 @@ int main() {
     Journal::Journal j2;
     bool loaded_json = j2.load_json(json_file);
     assert(loaded_json);
-    assert(j2.entries().size() == 1);
+    assert(j2.entries().size() == 2);
     assert(j2.entries()[0].symbol == "BTC");
+    assert(j2.entries()[0].side == Journal::Side::Buy);
+    assert(j2.entries()[1].side == Journal::Side::Sell);
     Journal::Journal j3;
     bool loaded_csv = j3.load_csv(csv_file);
     assert(loaded_csv);
-    assert(j3.entries().size() == 1);
-    assert(j3.entries()[0].side == "BUY");
+    assert(j3.entries().size() == 2);
+    assert(j3.entries()[0].side == Journal::Side::Buy);
+    assert(j3.entries()[1].side == Journal::Side::Sell);
     std::filesystem::remove_all(dir);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `Side` enum for journal entries with conversion helpers
- serialize/deserialize enum values to string for JSON and CSV
- update UI and tests to work with the enum and cover both buy and sell trades

## Testing
- `g++ -std=c++17 tests/test_journal.cpp src/journal.cpp -I./src -o /tmp/test_journal && /tmp/test_journal && echo test_journal_passed`
- `g++ -std=c++17 tests/test_signal.cpp src/signal.cpp -I./src -o /tmp/test_signal && /tmp/test_signal && echo test_signal_passed`
- `g++ -std=c++17 tests/test_candle_manager.cpp src/core/candle_manager.cpp -I./src -I./src/core -o /tmp/test_candle_manager && /tmp/test_candle_manager && echo test_candle_manager_passed`


------
https://chatgpt.com/codex/tasks/task_e_68985ddec1fc832787d217ec3d9f4cf9