### PR TITLE
Add unit test for backtester and make app build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,51 +4,69 @@ project(TradingTerminal LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find all necessary packages using vcpkg
-find_package(imgui CONFIG REQUIRED)
-find_package(implot CONFIG REQUIRED)
-find_package(cpr CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
-find_package(Arrow CONFIG REQUIRED)
-find_package(glfw3 CONFIG REQUIRED)
-find_package(OpenGL REQUIRED)
+option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" OFF)
 
-add_executable(TradingTerminal
-    main.cpp
-    src/config.cpp
-    src/candle.cpp
-    src/signal.cpp
-    src/plot/candlestick.cpp
-    src/core/candle_manager.cpp
-    src/core/data_fetcher.cpp
+if(BUILD_TRADING_TERMINAL)
+    # Find all necessary packages using vcpkg
+    find_package(imgui CONFIG REQUIRED)
+    find_package(implot CONFIG REQUIRED)
+    find_package(cpr CONFIG REQUIRED)
+    find_package(nlohmann_json CONFIG REQUIRED)
+    find_package(Arrow CONFIG REQUIRED)
+    find_package(glfw3 CONFIG REQUIRED)
+    find_package(OpenGL REQUIRED)
+
+    add_executable(TradingTerminal
+        main.cpp
+        src/config.cpp
+        src/candle.cpp
+        src/signal.cpp
+        src/plot/candlestick.cpp
+        src/core/candle_manager.cpp
+        src/core/data_fetcher.cpp
+        src/core/backtester.cpp
+        src/journal.cpp
+        src/ui/control_panel.cpp
+        src/ui/signals_window.cpp
+        src/ui/analytics_window.cpp
+        src/ui/journal_window.cpp
+        src/ui/chart_window.cpp
+    )
+
+    target_sources(TradingTerminal PRIVATE
+        ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp
+        ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_opengl3.cpp
+    )
+
+    # Link libraries to the executable
+    target_link_libraries(TradingTerminal PRIVATE
+        imgui::imgui
+        implot::implot
+        cpr::cpr
+        nlohmann_json::nlohmann_json
+        arrow_shared
+        glfw
+        OpenGL::GL
+    )
+
+    # Include directories if needed (vcpkg handles most of this automatically)
+    target_include_directories(TradingTerminal PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/backends
+    )
+endif()
+
+enable_testing()
+
+add_executable(test_backtester
+    tests/test_backtester.cpp
     src/core/backtester.cpp
-    src/journal.cpp
-    src/ui/control_panel.cpp
-    src/ui/signals_window.cpp
-    src/ui/analytics_window.cpp
-    src/ui/journal_window.cpp
-    src/ui/chart_window.cpp
+    src/candle.cpp
 )
 
-target_sources(TradingTerminal PRIVATE
-    ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp
-    ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_opengl3.cpp
-)
-
-# Link libraries to the executable
-target_link_libraries(TradingTerminal PRIVATE
-    imgui::imgui
-    implot::implot
-    cpr::cpr
-    nlohmann_json::nlohmann_json
-    arrow_shared
-    glfw
-    OpenGL::GL
-)
-
-# Include directories if needed (vcpkg handles most of this automatically)
-target_include_directories(TradingTerminal PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
+target_include_directories(test_backtester PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/backends
 )
+
+add_test(NAME test_backtester COMMAND test_backtester)

--- a/tests/test_backtester.cpp
+++ b/tests/test_backtester.cpp
@@ -1,0 +1,60 @@
+#include "core/backtester.h"
+#include <cassert>
+#include <vector>
+
+// Mock strategy generating predetermined signals
+class MockStrategy : public Core::IStrategy {
+public:
+    explicit MockStrategy(const std::vector<int>& sigs) : signals(sigs) {}
+    int generate_signal(const std::vector<Core::Candle>& /*candles*/, size_t index) override {
+        if (index < signals.size()) return signals[index];
+        return 0;
+    }
+private:
+    std::vector<int> signals;
+};
+
+int main() {
+    using namespace Core;
+    // Construct a minimal candle sequence
+    std::vector<Candle> candles;
+    double closes[] = {10, 11, 12, 11, 13, 12};
+    for (size_t i = 0; i < 6; ++i) {
+        candles.emplace_back(static_cast<long long>(i), 0, 0, 0, closes[i], 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    // Deterministic signals: buy, hold, sell, buy, hold, sell
+    std::vector<int> signals = {1, 0, -1, 1, 0, -1};
+    MockStrategy strategy(signals);
+
+    Backtester backtester(candles, strategy);
+    BacktestResult result = backtester.run();
+
+    // Verify trades
+    assert(result.trades.size() == 2);
+    assert(result.trades[0].entry_index == 0);
+    assert(result.trades[0].exit_index == 2);
+    assert(result.trades[0].entry_price == 10);
+    assert(result.trades[0].exit_price == 12);
+    assert(result.trades[0].pnl == 2);
+
+    assert(result.trades[1].entry_index == 3);
+    assert(result.trades[1].exit_index == 5);
+    assert(result.trades[1].entry_price == 11);
+    assert(result.trades[1].exit_price == 12);
+    assert(result.trades[1].pnl == 1);
+
+    // Verify PnL and win rate
+    assert(result.total_pnl == 3);
+    assert(result.win_rate == 1.0);
+
+    // Verify equity curve
+    std::vector<double> expected_equity = {0, 1, 2, 2, 4, 3};
+    assert(result.equity_curve.size() == expected_equity.size());
+    for (size_t i = 0; i < expected_equity.size(); ++i) {
+        assert(result.equity_curve[i] == expected_equity[i]);
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add deterministic unit test verifying Backtester trades, PnL, win rate and equity curve
- make TradingTerminal build optional and compile the new test via CMake

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689869c35a248327ba7073a410d15487