### PR TITLE
Enable TradingTerminal build by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(TradingTerminal LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" OFF)
+option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
 if(BUILD_TRADING_TERMINAL)
     # Find all necessary packages using vcpkg


### PR DESCRIPTION
## Summary
- Enable TradingTerminal to build by default by setting `BUILD_TRADING_TERMINAL` option to ON

## Testing
- `cmake .. && cmake --build . && ctest` *(fails: Could not find a package configuration file provided by "imgui" with any of the following names: imguiConfig.cmake, imgui-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6898702d482483279d7370ba3e62620c