### PR TITLE
Enable trading terminal build in batch scripts

### DIFF
--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -10,7 +10,7 @@ echo Changing to build directory...
 cd "%BUILD_DIR%"
 
 echo Running CMake configuration...
-cmake .. -DCMAKE_TOOLCHAIN_FILE="%VCPKG_TOOLCHAIN_FILE%"
+cmake .. -DBUILD_TRADING_TERMINAL=ON -DCMAKE_TOOLCHAIN_FILE="%VCPKG_TOOLCHAIN_FILE%"
 if %errorlevel% neq 0 (
     echo CMake configuration failed!
     goto :eof

--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -34,7 +34,7 @@ mkdir "%BUILD_DIR%"
 cd /d "%BUILD_DIR%"
 
 echo Running CMake configuration...
-cmake .. -DCMAKE_TOOLCHAIN_FILE="%TOOLCHAIN_FILE%"
+cmake .. -DBUILD_TRADING_TERMINAL=ON -DCMAKE_TOOLCHAIN_FILE="%TOOLCHAIN_FILE%"
 if %errorlevel% neq 0 (
     echo CMake configuration failed!
     pause


### PR DESCRIPTION
## Summary
- pass `-DBUILD_TRADING_TERMINAL=ON` to CMake in `build_and_run.bat`
- pass `-DBUILD_TRADING_TERMINAL=ON` to CMake in `setup_and_build.bat`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "imgui"...)*

------
https://chatgpt.com/codex/tasks/task_e_689871341c2c8327b0492e792d16b31a