### PR TITLE
Handle open position at end of backtest

### DIFF
--- a/src/core/backtester.cpp
+++ b/src/core/backtester.cpp
@@ -41,6 +41,20 @@ BacktestResult Backtester::run() {
         result.equity_curve.push_back(equity);
     }
 
+    // If still in a position, close it at the last available price
+    if (in_position && !m_candles.empty()) {
+        double exit_price = m_candles.back().close;
+        double pnl = exit_price - entry_price;
+        result.trades.push_back({entry_index, m_candles.size() - 1, entry_price, exit_price, pnl});
+        total_pnl += pnl;
+        if (pnl > 0) {
+            ++wins;
+        }
+        if (!result.equity_curve.empty()) {
+            result.equity_curve.back() = total_pnl;
+        }
+    }
+
     result.total_pnl = total_pnl;
     if (!result.trades.empty()) {
         result.win_rate = static_cast<double>(wins) / result.trades.size();

--- a/tests/test_backtester.cpp
+++ b/tests/test_backtester.cpp
@@ -55,6 +55,40 @@ int main() {
         assert(result.equity_curve[i] == expected_equity[i]);
     }
 
+    // Scenario: open position at the end should be closed automatically
+    {
+        std::vector<Candle> candles2;
+        double closes2[] = {10, 12, 11};
+        for (size_t i = 0; i < 3; ++i) {
+            candles2.emplace_back(static_cast<long long>(i), 0, 0, 0, closes2[i], 0, 0, 0, 0, 0, 0, 0);
+        }
+
+        std::vector<int> signals2 = {1, 0, 0};
+        MockStrategy strategy2(signals2);
+
+        Backtester backtester2(candles2, strategy2);
+        BacktestResult result2 = backtester2.run();
+
+        // A single trade that exits on the last candle
+        assert(result2.trades.size() == 1);
+        assert(result2.trades[0].entry_index == 0);
+        assert(result2.trades[0].exit_index == 2);
+        assert(result2.trades[0].entry_price == 10);
+        assert(result2.trades[0].exit_price == 11);
+        assert(result2.trades[0].pnl == 1);
+
+        // PnL and win rate
+        assert(result2.total_pnl == 1);
+        assert(result2.win_rate == 1.0);
+
+        // Equity curve should reflect the final realized PnL
+        std::vector<double> expected_equity2 = {0, 2, 1};
+        assert(result2.equity_curve.size() == expected_equity2.size());
+        for (size_t i = 0; i < expected_equity2.size(); ++i) {
+            assert(result2.equity_curve[i] == expected_equity2[i]);
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Close any remaining open position at the last candle price
- Update total PnL, wins count and equity curve when finalizing last trade
- Add regression test covering auto-closure of an open position

## Testing
- `g++ -std=c++17 -Isrc src/candle.cpp src/core/backtester.cpp tests/test_backtester.cpp -o tests/test_backtester && ./tests/test_backtester`


------
https://chatgpt.com/codex/tasks/task_e_68987410aefc83279ecb7bac141880a6