### PR TITLE
Add retry handling for data fetch errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,197 +1,218 @@
+#include "config.h"
+#include "core/backtester.h"
+#include "core/candle.h"
+#include "core/candle_manager.h"
+#include "core/data_fetcher.h"
 #include "imgui.h"
 #include "implot.h"
-#include "plot/candlestick.h"
-#include "core/candle.h"
-#include "core/data_fetcher.h"
-#include "config.h"
-#include "core/candle_manager.h"
 #include "journal.h"
-#include "core/backtester.h"
+#include "plot/candlestick.h"
 #include "signal.h"
 
-#include <map>
-#include <vector>
-#include <string>
-#include <chrono>
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <future>
+#include <map>
 #include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 #include <GLFW/glfw3.h>
 
-#include "ui/control_panel.h"
-#include "ui/signals_window.h"
 #include "ui/analytics_window.h"
-#include "ui/journal_window.h"
 #include "ui/chart_window.h"
+#include "ui/control_panel.h"
+#include "ui/journal_window.h"
+#include "ui/signals_window.h"
 
 using namespace Core;
 
 int main() {
-    // Init GLFW
-    if (!glfwInit()) return -1;
+  // Init GLFW
+  if (!glfwInit())
+    return -1;
 
-    // Create window with OpenGL context
-    GLFWwindow* window = glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
-    if (!window) return -1;
-    glfwMakeContextCurrent(window);
-    glfwSwapInterval(1); // Enable vsync
+  // Create window with OpenGL context
+  GLFWwindow *window =
+      glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
+  if (!window)
+    return -1;
+  glfwMakeContextCurrent(window);
+  glfwSwapInterval(1); // Enable vsync
 
-    // Setup Dear ImGui context
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImPlot::CreateContext();
-    ImGuiIO& io = ImGui::GetIO(); (void)io;
-    ImGui::StyleColorsDark();
+  // Setup Dear ImGui context
+  IMGUI_CHECKVERSION();
+  ImGui::CreateContext();
+  ImPlot::CreateContext();
+  ImGuiIO &io = ImGui::GetIO();
+  (void)io;
+  ImGui::StyleColorsDark();
 
-    // Setup Platform/Renderer bindings
-    ImGui_ImplGlfw_InitForOpenGL(window, true);
-    ImGui_ImplOpenGL3_Init("#version 130");
+  // Setup Platform/Renderer bindings
+  ImGui_ImplGlfw_InitForOpenGL(window, true);
+  ImGui_ImplOpenGL3_Init("#version 130");
 
-    // Load config
-    std::vector<std::string> pair_names = Config::load_selected_pairs("config.json");
-    if (pair_names.empty()) pair_names.push_back("BTCUSDT");
-    std::vector<PairItem> pairs;
-    for (const auto& name : pair_names) {
-        pairs.push_back({name, true});
+  // Load config
+  std::vector<std::string> pair_names =
+      Config::load_selected_pairs("config.json");
+  if (pair_names.empty())
+    pair_names.push_back("BTCUSDT");
+  std::vector<PairItem> pairs;
+  for (const auto &name : pair_names) {
+    pairs.push_back({name, true});
+  }
+
+  auto save_pairs = [&]() {
+    std::vector<std::string> names;
+    for (const auto &p : pairs)
+      names.push_back(p.name);
+    Config::save_selected_pairs("config.json", names);
+  };
+
+  std::vector<std::string> selected_pairs = pair_names;
+  std::string active_pair = selected_pairs[0];
+  std::string active_interval = "1m";
+
+  // Prepare candle storage by pair and interval
+  const std::vector<std::string> intervals = {"1m", "5m", "15m",
+                                              "1h", "4h", "1d"};
+  std::string selected_interval = "1m";
+  int short_period = 9;
+  int long_period = 21;
+  bool show_on_chart = false;
+  std::vector<SignalEntry> signal_entries;
+  std::vector<double> buy_times, buy_prices, sell_times, sell_prices;
+
+  std::map<std::string, std::map<std::string, std::vector<Candle>>> all_candles;
+  std::mutex candles_mutex; // protects access to all_candles
+  std::map<std::string, std::future<std::optional<std::vector<Candle>>>>
+      pending_fetches;
+  Journal::Journal journal;
+  journal.load_json("journal.json");
+  Core::BacktestResult last_result;
+
+  for (const auto &pair : selected_pairs) {
+    for (const auto &interval : intervals) {
+      auto candles = CandleManager::load_candles(pair, interval);
+      if (candles.empty()) {
+        auto fetched = DataFetcher::fetch_klines(pair, interval, 5000);
+        if (fetched && !fetched->empty()) {
+          candles = *fetched;
+          CandleManager::save_candles(pair, interval, candles);
+        }
+      }
+      all_candles[pair][interval] = candles;
+    }
+  }
+
+  // Main loop
+  while (!glfwWindowShouldClose(window)) {
+    glfwPollEvents();
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+
+    static auto last_fetch = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_fetch >= std::chrono::minutes(1)) {
+      for (const auto &item : pairs) {
+        const auto &pair = item.name;
+        if (pending_fetches.find(pair) == pending_fetches.end()) {
+          pending_fetches[pair] =
+              DataFetcher::fetch_klines_async(pair, "1m", 1);
+        }
+      }
+      last_fetch = now;
+    }
+    for (auto it = pending_fetches.begin(); it != pending_fetches.end();) {
+      if (it->second.wait_for(std::chrono::seconds(0)) ==
+          std::future_status::ready) {
+        auto latest = it->second.get();
+        if (latest && !latest->empty()) {
+          std::lock_guard<std::mutex> lock(candles_mutex);
+          auto &vec = all_candles[it->first]["1m"];
+          if (vec.empty() || latest->back().open_time > vec.back().open_time) {
+            vec.push_back(latest->back());
+            CandleManager::append_candles(it->first, "1m", {latest->back()});
+          }
+        }
+        it = pending_fetches.erase(it);
+      } else {
+        ++it;
+      }
     }
 
-    auto save_pairs = [&]() {
-        std::vector<std::string> names;
-        for (const auto& p : pairs) names.push_back(p.name);
-        Config::save_selected_pairs("config.json", names);
-    };
+    DrawControlPanel(pairs, selected_pairs, active_pair, active_interval,
+                     intervals, selected_interval, all_candles, save_pairs);
 
-    std::vector<std::string> selected_pairs = pair_names;
-    std::string active_pair = selected_pairs[0];
-    std::string active_interval = "1m";
+    DrawSignalsWindow(short_period, long_period, show_on_chart, signal_entries,
+                      buy_times, buy_prices, sell_times, sell_prices,
+                      all_candles, active_pair, selected_interval);
 
-    // Prepare candle storage by pair and interval
-    const std::vector<std::string> intervals = {"1m", "5m", "15m", "1h", "4h", "1d"};
-    std::string selected_interval = "1m";
-    int short_period = 9;
-    int long_period = 21;
-    bool show_on_chart = false;
-    std::vector<SignalEntry> signal_entries;
-    std::vector<double> buy_times, buy_prices, sell_times, sell_prices;
+    DrawAnalyticsWindow(all_candles, active_pair, selected_interval);
 
-    std::map<std::string, std::map<std::string, std::vector<Candle>>> all_candles;
-    std::mutex candles_mutex; // protects access to all_candles
-    std::map<std::string, std::future<std::vector<Candle>>> pending_fetches;
-    Journal::Journal journal;
-    journal.load_json("journal.json");
-    Core::BacktestResult last_result;
+    DrawJournalWindow(journal);
 
-    for (const auto& pair : selected_pairs) {
-        for (const auto& interval : intervals) {
-            auto candles = CandleManager::load_candles(pair, interval);
-            if (candles.empty()) {
-                candles = DataFetcher::fetch_klines(pair, interval, 5000);
-                if (!candles.empty()) {
-                    CandleManager::save_candles(pair, interval, candles);
-                }
-            }
-            all_candles[pair][interval] = candles;
+    // Backtest Window
+    ImGui::Begin("Backtest");
+    static int short_p = 9;
+    static int long_p = 21;
+    ImGui::InputInt("Short SMA", &short_p);
+    ImGui::InputInt("Long SMA", &long_p);
+    if (ImGui::Button("Run Backtest")) {
+      struct Strat : Core::IStrategy {
+        int s, l;
+        Strat(int sp, int lp) : s(sp), l(lp) {}
+        int generate_signal(const std::vector<Candle> &candles,
+                            size_t index) override {
+          return Signal::sma_crossover_signal(candles, index, s, l);
         }
+      } strat(short_p, long_p);
+      auto it = all_candles.find(active_pair);
+      if (it != all_candles.end()) {
+        Core::Backtester bt(it->second, strat);
+        last_result = bt.run();
+      }
     }
-
-    // Main loop
-    while (!glfwWindowShouldClose(window)) {
-        glfwPollEvents();
-        ImGui_ImplOpenGL3_NewFrame();
-        ImGui_ImplGlfw_NewFrame();
-        ImGui::NewFrame();
-
-        static auto last_fetch = std::chrono::steady_clock::now();
-        auto now = std::chrono::steady_clock::now();
-        if (now - last_fetch >= std::chrono::minutes(1)) {
-            for (const auto& item : pairs) {
-                const auto& pair = item.name;
-                if (pending_fetches.find(pair) == pending_fetches.end()) {
-                    pending_fetches[pair] = DataFetcher::fetch_klines_async(pair, "1m", 1);
-                }
-            }
-            last_fetch = now;
-        }
-        for (auto it = pending_fetches.begin(); it != pending_fetches.end(); ) {
-            if (it->second.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                auto latest = it->second.get();
-                if (!latest.empty()) {
-                    std::lock_guard<std::mutex> lock(candles_mutex);
-                    auto& vec = all_candles[it->first]["1m"];
-                    if (vec.empty() || latest.back().open_time > vec.back().open_time) {
-                        vec.push_back(latest.back());
-                        CandleManager::append_candles(it->first, "1m", {latest.back()});
-                    }
-                }
-                it = pending_fetches.erase(it);
-            } else {
-                ++it;
-            }
-        }
-
-        DrawControlPanel(pairs, selected_pairs, active_pair, active_interval, intervals, selected_interval, all_candles, save_pairs);
-
-        DrawSignalsWindow(short_period, long_period, show_on_chart, signal_entries, buy_times, buy_prices, sell_times, sell_prices, all_candles, active_pair, selected_interval);
-
-        DrawAnalyticsWindow(all_candles, active_pair, selected_interval);
-
-        DrawJournalWindow(journal);
-
-        // Backtest Window
-        ImGui::Begin("Backtest");
-        static int short_p = 9;
-        static int long_p = 21;
-        ImGui::InputInt("Short SMA", &short_p);
-        ImGui::InputInt("Long SMA", &long_p);
-        if (ImGui::Button("Run Backtest")) {
-            struct Strat : Core::IStrategy {
-                int s, l;
-                Strat(int sp, int lp) : s(sp), l(lp) {}
-                int generate_signal(const std::vector<Candle>& candles, size_t index) override {
-                    return Signal::sma_crossover_signal(candles, index, s, l);
-                }
-            } strat(short_p, long_p);
-            auto it = all_candles.find(active_pair);
-            if (it != all_candles.end()) {
-                Core::Backtester bt(it->second, strat);
-                last_result = bt.run();
-            }
-        }
-        if (!last_result.equity_curve.empty()) {
-            ImGui::Text("Total PnL: %.2f", last_result.total_pnl);
-            ImGui::Text("Win rate: %.2f%%", last_result.win_rate * 100.0);
-            if (ImPlot::BeginPlot("Equity")) {
-                std::vector<double> x(last_result.equity_curve.size());
-                for (size_t i = 0; i < x.size(); ++i) x[i] = static_cast<double>(i);
-                ImPlot::PlotLine("Equity", x.data(), last_result.equity_curve.data(), x.size());
-                ImPlot::EndPlot();
-            }
-        }
-        ImGui::End();
-
-        DrawChartWindow(all_candles, active_pair, active_interval, show_on_chart, buy_times, buy_prices, sell_times, sell_prices, journal, last_result);
-
-        ImGui::Render();
-        int display_w, display_h;
-        glfwGetFramebufferSize(window, &display_w, &display_h);
-        glViewport(0, 0, display_w, display_h);
-        glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
-        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-        glfwSwapBuffers(window);
+    if (!last_result.equity_curve.empty()) {
+      ImGui::Text("Total PnL: %.2f", last_result.total_pnl);
+      ImGui::Text("Win rate: %.2f%%", last_result.win_rate * 100.0);
+      if (ImPlot::BeginPlot("Equity")) {
+        std::vector<double> x(last_result.equity_curve.size());
+        for (size_t i = 0; i < x.size(); ++i)
+          x[i] = static_cast<double>(i);
+        ImPlot::PlotLine("Equity", x.data(), last_result.equity_curve.data(),
+                         x.size());
+        ImPlot::EndPlot();
+      }
     }
+    ImGui::End();
 
-    // Cleanup
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImPlot::DestroyContext();
-    ImGui::DestroyContext();
-    glfwDestroyWindow(window);
-    glfwTerminate();
+    DrawChartWindow(all_candles, active_pair, active_interval, show_on_chart,
+                    buy_times, buy_prices, sell_times, sell_prices, journal,
+                    last_result);
 
-    return 0;
+    ImGui::Render();
+    int display_w, display_h;
+    glfwGetFramebufferSize(window, &display_w, &display_h);
+    glViewport(0, 0, display_w, display_h);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    glfwSwapBuffers(window);
+  }
+
+  // Cleanup
+  ImGui_ImplOpenGL3_Shutdown();
+  ImGui_ImplGlfw_Shutdown();
+  ImPlot::DestroyContext();
+  ImGui::DestroyContext();
+  glfwDestroyWindow(window);
+  glfwTerminate();
+
+  return 0;
 }

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -1,67 +1,61 @@
 #include "data_fetcher.h"
+#include <chrono>
 #include <cpr/cpr.h>
-#include <nlohmann/json.hpp>
-#include <iostream>
-#include <vector>
 #include <future>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <thread>
+#include <vector>
 
 namespace Core {
 
-std::vector<Candle> DataFetcher::fetch_klines(const std::string& symbol, const std::string& interval, int limit) {
-    std::vector<Candle> candles;
-    std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
-                       "&interval=" + interval + "&limit=" + std::to_string(limit);
+std::optional<std::vector<Candle>>
+DataFetcher::fetch_klines(const std::string &symbol,
+                          const std::string &interval, int limit) {
+  const int max_retries = 3;
+  const auto retry_delay = std::chrono::seconds(1);
+  std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
+                    "&interval=" + interval + "&limit=" + std::to_string(limit);
+  for (int attempt = 0; attempt < max_retries; ++attempt) {
     cpr::Response r = cpr::Get(cpr::Url{url});
-
     if (r.status_code == 200) {
-        try {
-            auto json_data = nlohmann::json::parse(r.text);
-            for (const auto& kline : json_data) {
-                // Binance kline data format:
-                // [0] Open time
-                // [1] Open
-                // [2] High
-                // [3] Low
-                // [4] Close
-                // [5] Volume
-                // [6] Close time
-                // [7] Quote asset volume
-                // [8] Number of trades
-                // [9] Taker buy base asset volume
-                // [10] Taker buy quote asset volume
-                // [11] Ignore
-                candles.emplace_back(
-                    kline[0].get<long long>(), // Open time
-                    std::stod(kline[1].get<std::string>()), // Open
-                    std::stod(kline[2].get<std::string>()), // High
-                    std::stod(kline[3].get<std::string>()), // Low
-                    std::stod(kline[4].get<std::string>()), // Close
-                    std::stod(kline[5].get<std::string>()), // Volume
-                    kline[6].get<long long>(), // Close time
-                    std::stod(kline[7].get<std::string>()), // Quote asset volume
-                    kline[8].get<int>(), // Number of trades
-                    std::stod(kline[9].get<std::string>()), // Taker buy base asset volume
-                    std::stod(kline[10].get<std::string>()), // Taker buy quote asset volume
-                    std::stod(kline[11].get<std::string>())  // Ignore
-                );
-            }
-        } catch (const nlohmann::json::exception& e) {
-            std::cerr << "JSON parsing error: " << e.what() << std::endl;
-        } catch (const std::exception& e) {
-            std::cerr << "Error processing kline data: " << e.what() << std::endl;
+      try {
+        std::vector<Candle> candles;
+        auto json_data = nlohmann::json::parse(r.text);
+        for (const auto &kline : json_data) {
+          candles.emplace_back(
+              kline[0].get<long long>(), std::stod(kline[1].get<std::string>()),
+              std::stod(kline[2].get<std::string>()),
+              std::stod(kline[3].get<std::string>()),
+              std::stod(kline[4].get<std::string>()),
+              std::stod(kline[5].get<std::string>()), kline[6].get<long long>(),
+              std::stod(kline[7].get<std::string>()), kline[8].get<int>(),
+              std::stod(kline[9].get<std::string>()),
+              std::stod(kline[10].get<std::string>()),
+              std::stod(kline[11].get<std::string>()));
         }
-    } else {
-        std::cerr << "HTTP Request failed with status code: " << r.status_code << std::endl;
-        std::cerr << "Response text: " << r.text << std::endl;
+        return candles;
+      } catch (const std::exception &e) {
+        std::cerr << "Error processing kline data: " << e.what() << std::endl;
+        return std::nullopt;
+      }
     }
-
-    return candles;
+    std::cerr << "HTTP Request failed with status code: " << r.status_code
+              << std::endl;
+    if (attempt < max_retries - 1) {
+      std::this_thread::sleep_for(retry_delay);
+    }
+  }
+  return std::nullopt;
 }
 
-std::future<std::vector<Candle>> DataFetcher::fetch_klines_async(const std::string& symbol, const std::string& interval, int limit) {
-    return std::async(std::launch::async, [symbol, interval, limit]() {
-        return fetch_klines(symbol, interval, limit);
-    });
+std::future<std::optional<std::vector<Candle>>>
+DataFetcher::fetch_klines_async(const std::string &symbol,
+                                const std::string &interval, int limit) {
+  return std::async(std::launch::async, [symbol, interval, limit]() {
+    return fetch_klines(symbol, interval, limit);
+  });
 }
 
 } // namespace Core

--- a/src/core/data_fetcher.h
+++ b/src/core/data_fetcher.h
@@ -1,26 +1,31 @@
 #pragma once
 
 #include "candle.h"
+#include <future>
+#include <optional>
 #include <string>
 #include <vector>
-#include <future>
 
 namespace Core {
 
 class DataFetcher {
 public:
-    // Fetches kline (candle) data from a specified API (e.g., Binance).
-    // symbol: Trading pair (e.g., "BTCUSDT")
-    // interval: Time interval (e.g., "5m", "1h", "1d")
-    // limit: Number of candles to fetch
-    static std::vector<Candle> fetch_klines(const std::string& symbol, const std::string& interval, int limit = 500);
+  // Fetches kline (candle) data from a specified API (e.g., Binance).
+  // symbol: Trading pair (e.g., "BTCUSDT")
+  // interval: Time interval (e.g., "5m", "1h", "1d")
+  // limit: Number of candles to fetch
+  static std::optional<std::vector<Candle>>
+  fetch_klines(const std::string &symbol, const std::string &interval,
+               int limit = 500);
 
-    // Asynchronously fetches kline data on a background thread.
-    // Returns a future that becomes ready with the fetched candles once
-    // the HTTP request completes. The function itself is thread-safe;
-    // callers must ensure synchronization when modifying shared candle data
-    // with the returned result.
-    static std::future<std::vector<Candle>> fetch_klines_async(const std::string& symbol, const std::string& interval, int limit = 500);
+  // Asynchronously fetches kline data on a background thread.
+  // Returns a future that becomes ready with the fetched candles once
+  // the HTTP request completes. The function itself is thread-safe;
+  // callers must ensure synchronization when modifying shared candle data
+  // with the returned result.
+  static std::future<std::optional<std::vector<Candle>>>
+  fetch_klines_async(const std::string &symbol, const std::string &interval,
+                     int limit = 500);
 };
 
 } // namespace Core

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -1,9 +1,9 @@
 #include "ui/control_panel.h"
 
-#include "imgui.h"
+#include "config.h"
 #include "core/candle_manager.h"
 #include "core/data_fetcher.h"
-#include "config.h"
+#include "imgui.h"
 
 #include <algorithm>
 #include <cctype>
@@ -11,143 +11,149 @@
 using namespace Core;
 
 void DrawControlPanel(
-    std::vector<PairItem>& pairs,
-    std::vector<std::string>& selected_pairs,
-    std::string& active_pair,
-    std::string& active_interval,
-    const std::vector<std::string>& intervals,
-    std::string& selected_interval,
-    std::map<std::string, std::map<std::string, std::vector<Candle>>>& all_candles,
-    const std::function<void()>& save_pairs) {
-    ImGui::Begin("Control Panel");
+    std::vector<PairItem> &pairs, std::vector<std::string> &selected_pairs,
+    std::string &active_pair, std::string &active_interval,
+    const std::vector<std::string> &intervals, std::string &selected_interval,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>>
+        &all_candles,
+    const std::function<void()> &save_pairs) {
+  ImGui::Begin("Control Panel");
 
-    ImGui::Text("Select pairs to load:");
-    static char new_symbol[32] = "";
-    static std::string load_error;
-    ImGui::InputText("##new_symbol", new_symbol, IM_ARRAYSIZE(new_symbol));
-    ImGui::SameLine();
-    if (ImGui::Button("Load Symbol")) {
-        std::string symbol(new_symbol);
-        symbol.erase(std::remove_if(symbol.begin(), symbol.end(),
-                                    [](unsigned char c) { return std::isspace(c) || c == '-'; }),
-                     symbol.end());
-        std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
-        bool valid = !symbol.empty() &&
-                     std::all_of(symbol.begin(), symbol.end(),
-                                 [](unsigned char c) { return std::isalnum(c); });
-        if (valid &&
-            std::none_of(pairs.begin(), pairs.end(),
-                         [&](const PairItem& p) { return p.name == symbol; })) {
-            pairs.push_back({symbol, true});
-            save_pairs();
-            if (std::find(selected_pairs.begin(), selected_pairs.end(), symbol) == selected_pairs.end()) {
-                selected_pairs.push_back(symbol);
-                Config::save_selected_pairs("config.json", selected_pairs);
-            }
-            bool failed = false;
-            for (const auto& interval : intervals) {
-                auto candles = CandleManager::load_candles(symbol, interval);
-                if (candles.empty()) {
-                    candles = DataFetcher::fetch_klines(symbol, interval, 5000);
-                    if (!candles.empty()) {
-                        CandleManager::save_candles(symbol, interval, candles);
-                    }
-                }
-                if (candles.empty()) {
-                    failed = true;
-                } else {
-                    all_candles[symbol][interval] = candles;
-                }
-            }
-            load_error = failed ? "Failed to load " + symbol : "";
+  ImGui::Text("Select pairs to load:");
+  static char new_symbol[32] = "";
+  static std::string load_error;
+  ImGui::InputText("##new_symbol", new_symbol, IM_ARRAYSIZE(new_symbol));
+  ImGui::SameLine();
+  if (ImGui::Button("Load Symbol")) {
+    std::string symbol(new_symbol);
+    symbol.erase(std::remove_if(symbol.begin(), symbol.end(),
+                                [](unsigned char c) {
+                                  return std::isspace(c) || c == '-';
+                                }),
+                 symbol.end());
+    std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
+    bool valid = !symbol.empty() &&
+                 std::all_of(symbol.begin(), symbol.end(),
+                             [](unsigned char c) { return std::isalnum(c); });
+    if (valid &&
+        std::none_of(pairs.begin(), pairs.end(),
+                     [&](const PairItem &p) { return p.name == symbol; })) {
+      pairs.push_back({symbol, true});
+      save_pairs();
+      if (std::find(selected_pairs.begin(), selected_pairs.end(), symbol) ==
+          selected_pairs.end()) {
+        selected_pairs.push_back(symbol);
+        Config::save_selected_pairs("config.json", selected_pairs);
+      }
+      bool failed = false;
+      for (const auto &interval : intervals) {
+        auto candles = CandleManager::load_candles(symbol, interval);
+        if (candles.empty()) {
+          auto fetched = DataFetcher::fetch_klines(symbol, interval, 5000);
+          if (fetched && !fetched->empty()) {
+            candles = *fetched;
+            CandleManager::save_candles(symbol, interval, candles);
+          }
         }
-        new_symbol[0] = '\0';
-    }
-    if (!load_error.empty()) {
-        ImGui::Text("%s", load_error.c_str());
-    }
-
-    for (auto it = pairs.begin(); it != pairs.end();) {
-        if (ImGui::Checkbox(it->name.c_str(), &it->visible)) {
-            if (!it->visible && active_pair == it->name) {
-                auto new_active = std::find_if(
-                    pairs.begin(), pairs.end(),
-                    [](const PairItem& p) { return p.visible; });
-                active_pair = new_active != pairs.end() ? new_active->name : std::string();
-            } else if (it->visible && active_pair.empty()) {
-                active_pair = it->name;
-            }
-        }
-        ImGui::SameLine();
-        if (ImGui::SmallButton((std::string("X##") + it->name).c_str())) {
-            std::string removed = it->name;
-            it = pairs.erase(it);
-            all_candles.erase(removed);
-            if (active_pair == removed) {
-                auto new_active = std::find_if(
-                    pairs.begin(), pairs.end(),
-                    [](const PairItem& p) { return p.visible; });
-                active_pair = new_active != pairs.end() ? new_active->name : std::string();
-            }
-            save_pairs();
+        if (candles.empty()) {
+          failed = true;
         } else {
-            ++it;
+          all_candles[symbol][interval] = candles;
         }
+      }
+      load_error = failed ? "Failed to load " + symbol : "";
     }
+    new_symbol[0] = '\0';
+  }
+  if (!load_error.empty()) {
+    ImGui::Text("%s", load_error.c_str());
+  }
 
-    ImGui::Separator();
-    ImGui::Text("Active chart:");
+  for (auto it = pairs.begin(); it != pairs.end();) {
+    if (ImGui::Checkbox(it->name.c_str(), &it->visible)) {
+      if (!it->visible && active_pair == it->name) {
+        auto new_active =
+            std::find_if(pairs.begin(), pairs.end(),
+                         [](const PairItem &p) { return p.visible; });
+        active_pair =
+            new_active != pairs.end() ? new_active->name : std::string();
+      } else if (it->visible && active_pair.empty()) {
+        active_pair = it->name;
+      }
+    }
+    ImGui::SameLine();
+    if (ImGui::SmallButton((std::string("X##") + it->name).c_str())) {
+      std::string removed = it->name;
+      it = pairs.erase(it);
+      all_candles.erase(removed);
+      if (active_pair == removed) {
+        auto new_active =
+            std::find_if(pairs.begin(), pairs.end(),
+                         [](const PairItem &p) { return p.visible; });
+        active_pair =
+            new_active != pairs.end() ? new_active->name : std::string();
+      }
+      save_pairs();
+    } else {
+      ++it;
+    }
+  }
 
-    for (const auto& item : pairs) {
-        if (!item.visible) continue;
-        const auto& pair = item.name;
-        if (ImGui::RadioButton(pair.c_str(), active_pair == pair)) {
-            active_pair = pair;
-            if (all_candles[pair][active_interval].empty()) {
-                auto candles = CandleManager::load_candles(pair, active_interval);
-                if (candles.empty()) {
-                    candles = DataFetcher::fetch_klines(pair, active_interval, 5000);
-                    if (!candles.empty()) {
-                        CandleManager::save_candles(pair, active_interval, candles);
-                    }
-                }
-                all_candles[pair][active_interval] = candles;
-            }
+  ImGui::Separator();
+  ImGui::Text("Active chart:");
+
+  for (const auto &item : pairs) {
+    if (!item.visible)
+      continue;
+    const auto &pair = item.name;
+    if (ImGui::RadioButton(pair.c_str(), active_pair == pair)) {
+      active_pair = pair;
+      if (all_candles[pair][active_interval].empty()) {
+        auto candles = CandleManager::load_candles(pair, active_interval);
+        if (candles.empty()) {
+          auto fetched = DataFetcher::fetch_klines(pair, active_interval, 5000);
+          if (fetched && !fetched->empty()) {
+            candles = *fetched;
+            CandleManager::save_candles(pair, active_interval, candles);
+          }
         }
+        all_candles[pair][active_interval] = candles;
+      }
     }
+  }
 
-    ImGui::Separator();
-    ImGui::Text("Interval:");
-    for (const auto& interval : intervals) {
-        if (ImGui::RadioButton(interval.c_str(), active_interval == interval)) {
-            active_interval = interval;
-            if (all_candles[active_pair][interval].empty()) {
-                auto candles = CandleManager::load_candles(active_pair, interval);
-                if (candles.empty()) {
-                    candles = DataFetcher::fetch_klines(active_pair, interval, 5000);
-                    if (!candles.empty()) {
-                        CandleManager::save_candles(active_pair, interval, candles);
-                    }
-                }
-                all_candles[active_pair][interval] = candles;
-            }
+  ImGui::Separator();
+  ImGui::Text("Interval:");
+  for (const auto &interval : intervals) {
+    if (ImGui::RadioButton(interval.c_str(), active_interval == interval)) {
+      active_interval = interval;
+      if (all_candles[active_pair][interval].empty()) {
+        auto candles = CandleManager::load_candles(active_pair, interval);
+        if (candles.empty()) {
+          auto fetched = DataFetcher::fetch_klines(active_pair, interval, 5000);
+          if (fetched && !fetched->empty()) {
+            candles = *fetched;
+            CandleManager::save_candles(active_pair, interval, candles);
+          }
         }
+        all_candles[active_pair][interval] = candles;
+      }
     }
+  }
 
-    ImGui::Separator();
-    ImGui::Text("Timeframe:");
-    if (ImGui::BeginCombo("##interval_combo", selected_interval.c_str())) {
-        for (const auto& interval : intervals) {
-            bool is_selected = (selected_interval == interval);
-            if (ImGui::Selectable(interval.c_str(), is_selected)) {
-                selected_interval = interval;
-            }
-            if (is_selected) {
-                ImGui::SetItemDefaultFocus();
-            }
-        }
-        ImGui::EndCombo();
+  ImGui::Separator();
+  ImGui::Text("Timeframe:");
+  if (ImGui::BeginCombo("##interval_combo", selected_interval.c_str())) {
+    for (const auto &interval : intervals) {
+      bool is_selected = (selected_interval == interval);
+      if (ImGui::Selectable(interval.c_str(), is_selected)) {
+        selected_interval = interval;
+      }
+      if (is_selected) {
+        ImGui::SetItemDefaultFocus();
+      }
     }
-    ImGui::End();
+    ImGui::EndCombo();
+  }
+  ImGui::End();
 }
-


### PR DESCRIPTION
## Summary
- return `std::optional<std::vector<Candle>>` from DataFetcher with retry-on-failure logic
- propagate optional results to UI and main loop and update async fetch interface

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "imgui")*

------
https://chatgpt.com/codex/tasks/task_e_689875464f288327b6adaed4236de4d8