### PR TITLE
Refine core logic and I/O handling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -39,8 +39,10 @@ int main() {
   // Create window with OpenGL context
   GLFWwindow *window =
       glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
-  if (!window)
+  if (!window) {
+    glfwTerminate();
     return -1;
+  }
   glfwMakeContextCurrent(window);
   glfwSwapInterval(1); // Enable vsync
 

--- a/src/candle.cpp
+++ b/src/candle.cpp
@@ -1,2 +1,10 @@
-// Пока пустой, но ты можешь в будущем сюда добавлять методы работы с Candle
+// Реализация методов для структуры Candle
 #include "core/candle.h"
+
+namespace Core {
+
+bool Candle::is_bullish() const {
+    return close > open;
+}
+
+} // namespace Core

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -31,6 +31,8 @@ void save_selected_pairs(const std::string& filename, const std::vector<std::str
         nlohmann::json j;
         j["pairs"] = pairs;
         out << j.dump(4);
+    } else {
+        std::cerr << "Failed to open " << filename << " for writing" << std::endl;
     }
 }
 

--- a/src/core/backtester.cpp
+++ b/src/core/backtester.cpp
@@ -8,6 +8,7 @@ Backtester::Backtester(const std::vector<Candle>& candles, IStrategy& strategy)
 
 BacktestResult Backtester::run() {
     BacktestResult result;
+    result.equity_curve.reserve(m_candles.size());
     bool in_position = false;
     double entry_price = 0.0;
     size_t entry_index = 0;

--- a/src/core/candle.h
+++ b/src/core/candle.h
@@ -26,6 +26,8 @@ struct Candle {
         : open_time(ot), open(o), high(h), low(l), close(c), volume(v),
           close_time(ct), quote_asset_volume(qav), number_of_trades(notr),
           taker_buy_base_asset_volume(tbbav), taker_buy_quote_asset_volume(tbqav), ignore(ign) {}
+
+    bool is_bullish() const;
 };
 
 } // namespace Core

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -122,21 +122,23 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
 
     // Write header
     file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore\n";
+    file.setf(std::ios::fixed);
+    file << std::setprecision(8);
 
     // Write candle data
     for (const auto& candle : candles) {
         file << candle.open_time << ","
-             << std::fixed << std::setprecision(8) << candle.open << ","
-             << std::fixed << std::setprecision(8) << candle.high << ","
-             << std::fixed << std::setprecision(8) << candle.low << ","
-             << std::fixed << std::setprecision(8) << candle.close << ","
-             << std::fixed << std::setprecision(8) << candle.volume << ","
+             << candle.open << ","
+             << candle.high << ","
+             << candle.low << ","
+             << candle.close << ","
+             << candle.volume << ","
              << candle.close_time << ","
-             << std::fixed << std::setprecision(8) << candle.quote_asset_volume << ","
+             << candle.quote_asset_volume << ","
              << candle.number_of_trades << ","
-             << std::fixed << std::setprecision(8) << candle.taker_buy_base_asset_volume << ","
-             << std::fixed << std::setprecision(8) << candle.taker_buy_quote_asset_volume << ","
-             << std::fixed << std::setprecision(8) << candle.ignore << "\n";
+             << candle.taker_buy_base_asset_volume << ","
+             << candle.taker_buy_quote_asset_volume << ","
+             << candle.ignore << "\n";
     }
 
     file.close();

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -51,12 +51,16 @@ bool Journal::load_csv(const std::string& filename) {
         std::getline(ss, e.symbol, ',');
         std::getline(ss, field, ',');
         e.side = side_from_string(field);
-        std::getline(ss, field, ',');
-        e.price = std::stod(field);
-        std::getline(ss, field, ',');
-        e.quantity = std::stod(field);
-        std::getline(ss, field, ',');
-        e.timestamp = std::stoll(field);
+        try {
+            std::getline(ss, field, ',');
+            e.price = std::stod(field);
+            std::getline(ss, field, ',');
+            e.quantity = std::stod(field);
+            std::getline(ss, field, ',');
+            e.timestamp = std::stoll(field);
+        } catch (const std::exception&) {
+            return false;
+        }
         m_entries.push_back(e);
     }
     return true;

--- a/src/signal.h
+++ b/src/signal.h
@@ -6,15 +6,15 @@
 namespace Signal {
 
 // Calculates simple moving average of candle close prices.
-double simple_moving_average(const std::vector<Core::Candle>& candles, std::size_t index, std::size_t period);
+[[nodiscard]] double simple_moving_average(const std::vector<Core::Candle>& candles, std::size_t index, std::size_t period);
 
 // Generates a trading signal based on SMA crossover.
 // Returns 1 when short SMA crosses above long SMA,
 // -1 when it crosses below, and 0 otherwise.
-int sma_crossover_signal(const std::vector<Core::Candle>& candles,
-                         std::size_t index,
-                         std::size_t short_period,
-                         std::size_t long_period);
+[[nodiscard]] int sma_crossover_signal(const std::vector<Core::Candle>& candles,
+                                       std::size_t index,
+                                       std::size_t short_period,
+                                       std::size_t long_period);
 
 } // namespace Signal
 


### PR DESCRIPTION
## Summary
- ensure GLFW cleans up when window creation fails
- add `Candle::is_bullish` helper and mark signal helpers as `[[nodiscard]]`
- reserve equity curve capacity and streamline candle saving formatting
- improve error handling for config and journal file IO

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68987840f0b48327bc250f600c198d91