### PR TITLE
Fix backtester invocation and align ImPlot usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
+find_package(nlohmann_json CONFIG REQUIRED)
+
 if(BUILD_TRADING_TERMINAL)
     # Find all necessary packages using vcpkg
     find_package(imgui CONFIG REQUIRED)
     find_package(implot CONFIG REQUIRED)
     find_package(cpr CONFIG REQUIRED)
-    find_package(nlohmann_json CONFIG REQUIRED)
     find_package(Arrow CONFIG REQUIRED)
     find_package(glfw3 CONFIG REQUIRED)
     find_package(OpenGL REQUIRED)
@@ -81,6 +82,8 @@ target_include_directories(test_candle_manager PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+target_link_libraries(test_candle_manager PRIVATE nlohmann_json::nlohmann_json)
+
 add_test(NAME test_candle_manager COMMAND test_candle_manager)
 
 add_executable(test_journal
@@ -91,6 +94,7 @@ add_executable(test_journal
 target_include_directories(test_journal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+target_link_libraries(test_journal PRIVATE nlohmann_json::nlohmann_json)
 
 add_test(NAME test_journal COMMAND test_journal)
 

--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -24,16 +24,17 @@ if %errorlevel% neq 0 (
 )
 
 echo Running the application...
-rem Try to run Debug version first, then Release if Debug not found
+pushd "%BUILD_DIR%"
 if exist "Debug\TradingTerminal.exe" (
-    start "" "Debug\TradingTerminal.exe" > "%PROJECT_DIR%\error_log.txt" 2>&1
+    start "" cmd /K ".\Debug\TradingTerminal.exe"
 ) else if exist "Release\TradingTerminal.exe" (
-    start "" "Release\TradingTerminal.exe" > "%PROJECT_DIR%\error_log.txt" 2>&1
+    start "" cmd /K ".\Release\TradingTerminal.exe"
+) else if exist "TradingTerminal.exe" (
+    start "" cmd /K "TradingTerminal.exe"
 ) else (
     echo Executable not found in Debug or Release folders.
 )
-
-echo Check error_log.txt for details.
+popd
 
 echo Done.
 pause

--- a/main.cpp
+++ b/main.cpp
@@ -174,10 +174,13 @@ int main() {
           return Signal::sma_crossover_signal(candles, index, s, l);
         }
       } strat(short_p, long_p);
-      auto it = all_candles.find(active_pair);
-      if (it != all_candles.end()) {
-        Core::Backtester bt(it->second, strat);
-        last_result = bt.run();
+      auto pair_it = all_candles.find(active_pair);
+      if (pair_it != all_candles.end()) {
+        auto interval_it = pair_it->second.find(active_interval);
+        if (interval_it != pair_it->second.end()) {
+          Core::Backtester bt(interval_it->second, strat);
+          last_result = bt.run();
+        }
       }
     }
     if (!last_result.equity_curve.empty()) {

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -71,18 +71,20 @@ void DrawChartWindow(
     }
     ImGui::SameLine();
     if (ImGui::Button("Fit")) {
-        ImPlot::FitNextPlotAxes();
+        ImPlot::SetNextAxesToFit();
         use_manual_limits = false;
     }
 
     if (use_manual_limits) {
-        ImPlot::SetNextPlotLimits(manual_limits.X.Min, manual_limits.X.Max,
-                                 manual_limits.Y.Min, manual_limits.Y.Max,
-                                 ImGuiCond_Always);
+        ImPlot::SetNextAxesLimits(manual_limits.X.Min, manual_limits.X.Max,
+                                  manual_limits.Y.Min, manual_limits.Y.Max,
+                                  ImGuiCond_Always);
     }
 
-    ImPlotFlags plot_flags = ImPlotFlags_ContextMenu | ImPlotFlags_Crosshairs;
-    if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), "Time", "Price", plot_flags)) {
+    ImPlotFlags plot_flags = ImPlotFlags_Crosshairs;
+    if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), ImVec2(-1,0), plot_flags)) {
+        ImPlot::SetupAxes("Time", "Price");
+        ImPlot::SetupLegend(ImPlotLocation_South, ImPlotLegendFlags_Outside);
         Plot::PlotCandlestick(
             "Candles",
             times.data(), opens.data(), closes.data(), lows.data(), highs.data(),
@@ -176,7 +178,6 @@ void DrawChartWindow(
         }
 
         ImPlot::EndPlot();
-        ImPlot::ShowAltLegend();
     }
     ImGui::End();
 }


### PR DESCRIPTION
## Summary
- Correct backtester to pull candle vector for active interval
- Update chart rendering to modern ImPlot API
- Ensure tests include nlohmann_json and open terminal from build directory

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68987bc3bd908327a64c74cfd3a9622b