### PR TITLE
Add basic logging system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BUILD_TRADING_TERMINAL)
         src/core/candle_manager.cpp
         src/core/data_fetcher.cpp
         src/core/backtester.cpp
+        src/logger.cpp
         src/journal.cpp
         src/ui/control_panel.cpp
         src/ui/signals_window.cpp

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "journal.h"
 #include "plot/candlestick.h"
 #include "signal.h"
+#include "logger.h"
 
 #include <algorithm>
 #include <cctype>
@@ -33,13 +34,19 @@ using namespace Core;
 
 int main() {
   // Init GLFW
-  if (!glfwInit())
+  Logger::instance().set_file("terminal.log");
+  Logger::instance().info("Application started");
+
+  if (!glfwInit()) {
+    Logger::instance().error("Failed to initialize GLFW");
     return -1;
+  }
 
   // Create window with OpenGL context
   GLFWwindow *window =
       glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
   if (!window) {
+    Logger::instance().error("Failed to create GLFW window");
     glfwTerminate();
     return -1;
   }
@@ -224,6 +231,8 @@ int main() {
   ImGui::DestroyContext();
   glfwDestroyWindow(window);
   glfwTerminate();
+
+  Logger::instance().info("Application exiting");
 
   return 0;
 }

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -2,7 +2,7 @@
 #include <chrono>
 #include <cpr/cpr.h>
 #include <future>
-#include <iostream>
+#include "logger.h"
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <thread>
@@ -37,12 +37,11 @@ DataFetcher::fetch_klines(const std::string &symbol,
         }
         return candles;
       } catch (const std::exception &e) {
-        std::cerr << "Error processing kline data: " << e.what() << std::endl;
+        Logger::instance().error(std::string("Error processing kline data: ") + e.what());
         return std::nullopt;
       }
     }
-    std::cerr << "HTTP Request failed with status code: " << r.status_code
-              << std::endl;
+    Logger::instance().error("HTTP Request failed with status code: " + std::to_string(r.status_code));
     if (attempt < max_retries - 1) {
       std::this_thread::sleep_for(retry_delay);
     }
@@ -71,12 +70,11 @@ std::optional<std::vector<std::string>> DataFetcher::fetch_all_symbols() {
       }
       return symbols;
     } catch (const std::exception &e) {
-      std::cerr << "Error processing symbol list: " << e.what() << std::endl;
+      Logger::instance().error(std::string("Error processing symbol list: ") + e.what());
       return std::nullopt;
     }
   }
-  std::cerr << "HTTP Request failed with status code: " << r.status_code
-            << std::endl;
+  Logger::instance().error("HTTP Request failed with status code: " + std::to_string(r.status_code));
   return std::nullopt;
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,48 @@
+#include "logger.h"
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+
+Logger &Logger::instance() {
+  static Logger inst;
+  return inst;
+}
+
+void Logger::set_file(const std::string &filename) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (out_.is_open())
+    out_.close();
+  out_.open(filename, std::ios::app);
+}
+
+std::string Logger::level_to_string(LogLevel level) {
+  switch (level) {
+  case LogLevel::Info:
+    return "INFO";
+  case LogLevel::Warning:
+    return "WARN";
+  case LogLevel::Error:
+    return "ERROR";
+  }
+  return "";
+}
+
+void Logger::log(LogLevel level, const std::string &message) {
+  using namespace std::chrono;
+  auto now = system_clock::now();
+  auto t = system_clock::to_time_t(now);
+  auto tm = *std::localtime(&t);
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (out_.is_open()) {
+    out_ << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " ["
+         << level_to_string(level) << "] " << message << std::endl;
+  }
+}
+
+void Logger::info(const std::string &message) { log(LogLevel::Info, message); }
+
+void Logger::warn(const std::string &message) { log(LogLevel::Warning, message); }
+
+void Logger::error(const std::string &message) { log(LogLevel::Error, message); }
+

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <fstream>
+#include <mutex>
+#include <string>
+
+enum class LogLevel { Info, Warning, Error };
+
+class Logger {
+public:
+  static Logger &instance();
+  void set_file(const std::string &filename);
+  void log(LogLevel level, const std::string &message);
+  void info(const std::string &message);
+  void warn(const std::string &message);
+  void error(const std::string &message);
+
+private:
+  Logger() = default;
+  std::ofstream out_;
+  std::mutex mutex_;
+  std::string level_to_string(LogLevel level);
+};
+


### PR DESCRIPTION
## Summary
- introduce thread-safe singleton logger for structured file logging
- log application lifecycle and HTTP errors
- wire logger into build

## Testing
- `cmake -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_6898910184a883279701681916583ca3