### PR TITLE
Add vcpkg install error handling to setup script

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -24,6 +24,12 @@ set TOOLCHAIN_FILE=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake
 
 echo Installing required packages...
 "%VCPKG_PATH%\vcpkg.exe" install imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl
+if %errorlevel% neq 0 (
+    echo Dependency installation failed!
+    pause
+    exit /b %errorlevel%
+)
+"%VCPKG_PATH%\vcpkg.exe" list
 
 set BUILD_DIR=%SCRIPT_DIR%build
 if exist "%BUILD_DIR%" (


### PR DESCRIPTION
## Summary
- add error handling for vcpkg dependency installation and list installed packages

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689899e40acc83278b231f58bc5092c4