### PR TITLE
Simplify vcpkg dependency installation

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -23,8 +23,7 @@ if exist "%VCPKG_PATH%" (
 set TOOLCHAIN_FILE=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake
 
 echo Installing required packages...
-"%VCPKG_PATH%\vcpkg.exe" install --recurse imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl
-"%VCPKG_PATH%\vcpkg.exe" install imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl
+"%VCPKG_PATH%\vcpkg.exe" install imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl --recurse
 if %errorlevel% neq 0 (
     echo Dependency installation failed!
     pause


### PR DESCRIPTION
## Summary
- consolidate vcpkg dependency installation into one command with `--recurse`

## Testing
- `bash setup_and_build.bat` *(fails: `@echo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68989d453b3c8327b214b173d36333e4