### PR TITLE
Enable ImGui docking in vcpkg install script

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -23,7 +23,7 @@ if exist "%VCPKG_PATH%" (
 set TOOLCHAIN_FILE=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake
 
 echo Installing required packages...
-"%VCPKG_PATH%\vcpkg.exe" install imgui[core,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl --recurse
+"%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl --recurse
 if %errorlevel% neq 0 (
     echo Dependency installation failed!
     pause


### PR DESCRIPTION
## Summary
- Enable `docking-experimental` feature in ImGui's vcpkg install command.

## Testing
- `wine cmd /c setup_and_build.bat` *(fails: wine32 missing and vcpkg path prompt)*
- `cmake -S . -B build` *(fails: Could not find nlohmann_json package)*

------
https://chatgpt.com/codex/tasks/task_e_6898a4dacb788327ab6d90b98f62f3b5