### PR TITLE
fix: provide dockspace id

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -128,7 +128,8 @@ int main() {
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
-    ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
+    ImGui::DockSpaceOverViewport(ImGui::GetID("MainDock"),
+                                 ImGui::GetMainViewport());
 
     static auto last_fetch = std::chrono::steady_clock::now();
     auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
## Summary
- update DockSpaceOverViewport call to supply explicit ID before viewport

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "imgui")*

------
https://chatgpt.com/codex/tasks/task_e_6898a80d9a2c8327a6af6c64a1e6cc66