### PR TITLE
Use thread-safe time conversion in logger

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -32,8 +32,13 @@ void Logger::log(LogLevel level, const std::string &message) {
   using namespace std::chrono;
   auto now = system_clock::now();
   auto t = system_clock::to_time_t(now);
-  auto tm = *std::localtime(&t);
   std::lock_guard<std::mutex> lock(mutex_);
+  std::tm tm;
+#if defined(_WIN32)
+  localtime_s(&tm, &t);
+#else
+  localtime_r(&t, &tm);
+#endif
   if (out_.is_open()) {
     out_ << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " ["
          << level_to_string(level) << "] " << message << std::endl;


### PR DESCRIPTION
## Summary
- replace `std::localtime` with thread-safe `localtime_s`/`localtime_r`
- compute local time inside logger's mutex

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`
- manual run of logger producing `2025-08-10 14:51:06 [INFO] hello world`


------
https://chatgpt.com/codex/tasks/task_e_6898b11429f4832787930bbc7d46b0cf