### PR TITLE
feat: parameterize data fetching and improve error handling

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -4,21 +4,46 @@
 #include <future>
 #include "logger.h"
 #include <nlohmann/json.hpp>
-#include <optional>
 #include <thread>
 #include <vector>
+#include <mutex>
+
+namespace {
+std::mutex request_mutex;
+std::chrono::steady_clock::time_point last_request =
+    std::chrono::steady_clock::now();
+
+void throttle(std::chrono::milliseconds pause) {
+  std::unique_lock<std::mutex> lock(request_mutex);
+  auto now = std::chrono::steady_clock::now();
+  auto next = last_request + pause;
+  if (now < next) {
+    std::this_thread::sleep_for(next - now);
+  }
+  last_request = std::chrono::steady_clock::now();
+}
+} // namespace
 
 namespace Core {
 
-std::optional<std::vector<Candle>>
-DataFetcher::fetch_klines(const std::string &symbol,
-                          const std::string &interval, int limit) {
-  const int max_retries = 3;
-  const auto retry_delay = std::chrono::seconds(1);
+KlinesResult DataFetcher::fetch_klines(
+    const std::string &symbol, const std::string &interval, int limit,
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) {
   std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
-                    "&interval=" + interval + "&limit=" + std::to_string(limit);
+                    "&interval=" + interval + "&limit=" +
+                    std::to_string(limit);
   for (int attempt = 0; attempt < max_retries; ++attempt) {
+    throttle(request_pause);
     cpr::Response r = cpr::Get(cpr::Url{url});
+    if (r.error.code != cpr::ErrorCode::OK) {
+      Logger::instance().error("Request error: " + r.error.message);
+      if (attempt < max_retries - 1) {
+        std::this_thread::sleep_for(retry_delay);
+        continue;
+      }
+      return {FetchError::NetworkError, 0, r.error.message, {}};
+    }
     if (r.status_code == 200) {
       try {
         std::vector<Candle> candles;
@@ -35,47 +60,73 @@ DataFetcher::fetch_klines(const std::string &symbol,
               std::stod(kline[10].get<std::string>()),
               std::stod(kline[11].get<std::string>()));
         }
-        return candles;
+        return {FetchError::None, r.status_code, "", candles};
       } catch (const std::exception &e) {
-        Logger::instance().error(std::string("Error processing kline data: ") + e.what());
-        return std::nullopt;
+        Logger::instance().error(std::string("Error processing kline data: ") +
+                                e.what());
+        return {FetchError::ParseError, r.status_code, e.what(), {}};
       }
     }
-    Logger::instance().error("HTTP Request failed with status code: " + std::to_string(r.status_code));
+    Logger::instance().error("HTTP Request failed with status code: " +
+                             std::to_string(r.status_code));
     if (attempt < max_retries - 1) {
       std::this_thread::sleep_for(retry_delay);
+    } else {
+      return {FetchError::HttpError, r.status_code, r.error.message, {}};
     }
   }
-  return std::nullopt;
+  return {FetchError::HttpError, 0, "Max retries exceeded", {}};
 }
 
-std::future<std::optional<std::vector<Candle>>>
-DataFetcher::fetch_klines_async(const std::string &symbol,
-                                const std::string &interval, int limit) {
-  return std::async(std::launch::async, [symbol, interval, limit]() {
-    return fetch_klines(symbol, interval, limit);
+std::future<KlinesResult> DataFetcher::fetch_klines_async(
+    const std::string &symbol, const std::string &interval, int limit,
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) {
+  return std::async(std::launch::async, [symbol, interval, limit, max_retries,
+                                        retry_delay, request_pause]() {
+    return fetch_klines(symbol, interval, limit, max_retries, retry_delay,
+                        request_pause);
   });
 }
 
-std::optional<std::vector<std::string>> DataFetcher::fetch_all_symbols() {
-  const std::string url =
-      "https://api.binance.com/api/v3/exchangeInfo";
-  cpr::Response r = cpr::Get(cpr::Url{url});
-  if (r.status_code == 200) {
-    try {
-      std::vector<std::string> symbols;
-      auto json_data = nlohmann::json::parse(r.text);
-      for (const auto &item : json_data["symbols"]) {
-        symbols.push_back(item["symbol"].get<std::string>());
+SymbolsResult DataFetcher::fetch_all_symbols(
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) {
+  const std::string url = "https://api.binance.com/api/v3/exchangeInfo";
+  for (int attempt = 0; attempt < max_retries; ++attempt) {
+    throttle(request_pause);
+    cpr::Response r = cpr::Get(cpr::Url{url});
+    if (r.error.code != cpr::ErrorCode::OK) {
+      Logger::instance().error("Request error: " + r.error.message);
+      if (attempt < max_retries - 1) {
+        std::this_thread::sleep_for(retry_delay);
+        continue;
       }
-      return symbols;
-    } catch (const std::exception &e) {
-      Logger::instance().error(std::string("Error processing symbol list: ") + e.what());
-      return std::nullopt;
+      return {FetchError::NetworkError, 0, r.error.message, {}};
+    }
+    if (r.status_code == 200) {
+      try {
+        std::vector<std::string> symbols;
+        auto json_data = nlohmann::json::parse(r.text);
+        for (const auto &item : json_data["symbols"]) {
+          symbols.push_back(item["symbol"].get<std::string>());
+        }
+        return {FetchError::None, r.status_code, "", symbols};
+      } catch (const std::exception &e) {
+        Logger::instance().error(std::string("Error processing symbol list: ") +
+                                e.what());
+        return {FetchError::ParseError, r.status_code, e.what(), {}};
+      }
+    }
+    Logger::instance().error("HTTP Request failed with status code: " +
+                             std::to_string(r.status_code));
+    if (attempt < max_retries - 1) {
+      std::this_thread::sleep_for(retry_delay);
+    } else {
+      return {FetchError::HttpError, r.status_code, r.error.message, {}};
     }
   }
-  Logger::instance().error("HTTP Request failed with status code: " + std::to_string(r.status_code));
-  return std::nullopt;
+  return {FetchError::HttpError, 0, "Max retries exceeded", {}};
 }
 
 } // namespace Core

--- a/src/core/data_fetcher.h
+++ b/src/core/data_fetcher.h
@@ -2,11 +2,33 @@
 
 #include "candle.h"
 #include <future>
-#include <optional>
 #include <string>
 #include <vector>
+#include <chrono>
 
 namespace Core {
+
+// Detailed error codes returned by DataFetcher functions.
+enum class FetchError {
+  None = 0,        // No error
+  HttpError = 1,   // Non-200 HTTP status
+  ParseError = 2,  // Failed to parse response
+  NetworkError = 3 // Network level failure
+};
+
+struct KlinesResult {
+  FetchError error{FetchError::None};
+  int http_status{0};
+  std::string message; // detailed message
+  std::vector<Candle> candles; // fetched candles
+};
+
+struct SymbolsResult {
+  FetchError error{FetchError::None};
+  int http_status{0};
+  std::string message;
+  std::vector<std::string> symbols;
+};
 
 class DataFetcher {
 public:
@@ -14,21 +36,37 @@ public:
   // symbol: Trading pair (e.g., "BTCUSDT")
   // interval: Time interval (e.g., "5m", "1h", "1d")
   // limit: Number of candles to fetch
-  static std::optional<std::vector<Candle>>
+  // max_retries: how many times to retry on failure
+  // retry_delay: delay between retries
+  // request_pause: enforced pause between requests to respect API limits
+  static KlinesResult
   fetch_klines(const std::string &symbol, const std::string &interval,
-               int limit = 500);
+               int limit = 500, int max_retries = 3,
+               std::chrono::milliseconds retry_delay =
+                   std::chrono::milliseconds(1000),
+               std::chrono::milliseconds request_pause =
+                   std::chrono::milliseconds(1100));
 
   // Asynchronously fetches kline data on a background thread.
   // Returns a future that becomes ready with the fetched candles once
   // the HTTP request completes. The function itself is thread-safe;
   // callers must ensure synchronization when modifying shared candle data
   // with the returned result.
-  static std::future<std::optional<std::vector<Candle>>>
+  static std::future<KlinesResult>
   fetch_klines_async(const std::string &symbol, const std::string &interval,
-                     int limit = 500);
+                     int limit = 500, int max_retries = 3,
+                     std::chrono::milliseconds retry_delay =
+                         std::chrono::milliseconds(1000),
+                     std::chrono::milliseconds request_pause =
+                         std::chrono::milliseconds(1100));
 
   // Fetch list of all available trading symbols from the exchange.
-  static std::optional<std::vector<std::string>> fetch_all_symbols();
+  static SymbolsResult
+  fetch_all_symbols(int max_retries = 3,
+                    std::chrono::milliseconds retry_delay =
+                        std::chrono::milliseconds(1000),
+                    std::chrono::milliseconds request_pause =
+                        std::chrono::milliseconds(1100));
 };
 
 } // namespace Core

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -14,19 +14,30 @@ void DataService::save_selected_pairs(
   Config::save_selected_pairs(filename, pairs);
 }
 
-std::optional<std::vector<std::string>> DataService::fetch_all_symbols() const {
-  return Core::DataFetcher::fetch_all_symbols();
+Core::SymbolsResult DataService::fetch_all_symbols(
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) const {
+  return Core::DataFetcher::fetch_all_symbols(max_retries, retry_delay,
+                                             request_pause);
 }
 
-std::optional<std::vector<Core::Candle>> DataService::fetch_klines(
-    const std::string &symbol, const std::string &interval, int limit) const {
-  return Core::DataFetcher::fetch_klines(symbol, interval, limit);
+Core::KlinesResult DataService::fetch_klines(
+    const std::string &symbol, const std::string &interval, int limit,
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) const {
+  return Core::DataFetcher::fetch_klines(symbol, interval, limit, max_retries,
+                                        retry_delay, request_pause);
 }
 
-std::future<std::optional<std::vector<Core::Candle>>>
+std::future<Core::KlinesResult>
 DataService::fetch_klines_async(const std::string &symbol,
-                                const std::string &interval, int limit) const {
-  return Core::DataFetcher::fetch_klines_async(symbol, interval, limit);
+                                const std::string &interval, int limit,
+                                int max_retries,
+                                std::chrono::milliseconds retry_delay,
+                                std::chrono::milliseconds request_pause) const {
+  return Core::DataFetcher::fetch_klines_async(symbol, interval, limit,
+                                               max_retries, retry_delay,
+                                               request_pause);
 }
 
 std::vector<Core::Candle>

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <future>
-#include <optional>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include "core/candle.h"
+#include "core/data_fetcher.h"
 
 // DataService groups configuration loading, candle storage and
 // network operations used by the application.  At the moment it is
@@ -20,11 +21,23 @@ public:
                            const std::vector<std::string> &pairs) const;
 
   // Exchange data ---------------------------------------------------------
-  std::optional<std::vector<std::string>> fetch_all_symbols() const;
-  std::optional<std::vector<Core::Candle>> fetch_klines(
-      const std::string &symbol, const std::string &interval, int limit) const;
-  std::future<std::optional<std::vector<Core::Candle>>> fetch_klines_async(
-      const std::string &symbol, const std::string &interval, int limit) const;
+  Core::SymbolsResult fetch_all_symbols(
+      int max_retries = 3,
+      std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
+      std::chrono::milliseconds request_pause =
+          std::chrono::milliseconds(1100)) const;
+  Core::KlinesResult fetch_klines(
+      const std::string &symbol, const std::string &interval, int limit,
+      int max_retries = 3,
+      std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
+      std::chrono::milliseconds request_pause =
+          std::chrono::milliseconds(1100)) const;
+  std::future<Core::KlinesResult> fetch_klines_async(
+      const std::string &symbol, const std::string &interval, int limit,
+      int max_retries = 3,
+      std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
+      std::chrono::milliseconds request_pause =
+          std::chrono::milliseconds(1100)) const;
 
   // Local storage ---------------------------------------------------------
   std::vector<Core::Candle> load_candles(const std::string &pair,

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -77,8 +77,9 @@ void DrawControlPanel(
         auto candles = CandleManager::load_candles(symbol, interval);
         if (candles.empty()) {
           auto fetched = DataFetcher::fetch_klines(symbol, interval, 5000);
-          if (fetched && !fetched->empty()) {
-            candles = *fetched;
+          if (fetched.error == FetchError::None &&
+              !fetched.candles.empty()) {
+            candles = fetched.candles;
             CandleManager::save_candles(symbol, interval, candles);
           }
         }
@@ -245,8 +246,9 @@ void DrawControlPanel(
         auto candles = CandleManager::load_candles(pair, active_interval);
         if (candles.empty()) {
           auto fetched = DataFetcher::fetch_klines(pair, active_interval, 5000);
-          if (fetched && !fetched->empty()) {
-            candles = *fetched;
+          if (fetched.error == FetchError::None &&
+              !fetched.candles.empty()) {
+            candles = fetched.candles;
             CandleManager::save_candles(pair, active_interval, candles);
           }
         }
@@ -264,8 +266,9 @@ void DrawControlPanel(
         auto candles = CandleManager::load_candles(active_pair, interval);
         if (candles.empty()) {
           auto fetched = DataFetcher::fetch_klines(active_pair, interval, 5000);
-          if (fetched && !fetched->empty()) {
-            candles = *fetched;
+          if (fetched.error == FetchError::None &&
+              !fetched.candles.empty()) {
+            candles = fetched.candles;
             CandleManager::save_candles(active_pair, interval, candles);
           }
         }


### PR DESCRIPTION
## Summary
- add FetchError enums and structured results for DataFetcher
- parameterize retries, delays, and inter-request pause
- enforce queued requests via mutex-based throttling
- propagate detailed errors through DataService and callers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "imgui")*


------
https://chatgpt.com/codex/tasks/task_e_689d8ee45d848327a1a346861d52ef3c