### PR TITLE
Add inline journal editing with formatted timestamps

### DIFF
--- a/src/ui/journal_window.cpp
+++ b/src/ui/journal_window.cpp
@@ -3,6 +3,10 @@
 #include "imgui.h"
 
 #include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <ctime>
+#include <cstring>
 
 void DrawJournalWindow(Journal::Journal& journal) {
     ImGui::Begin("Journal");
@@ -32,20 +36,90 @@ void DrawJournalWindow(Journal::Journal& journal) {
         journal.save_json("journal.json");
         journal.save_csv("journal.csv");
     }
-    if (ImGui::BeginTable("JournalTable", 5, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+
+    static int edit_index = -1;
+    static char edit_symbol[32];
+    static int edit_side = 0;
+    static double edit_price = 0.0;
+    static double edit_qty = 0.0;
+    static char edit_time[20];
+
+    auto format_timestamp = [](std::int64_t ms) {
+        std::time_t t = ms / 1000;
+        std::tm tm = *std::localtime(&t);
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%d %H:%M");
+        return oss.str();
+    };
+
+    auto parse_timestamp = [](const char* str, std::int64_t& out_ms) {
+        std::tm tm{};
+        std::istringstream iss(str);
+        iss >> std::get_time(&tm, "%Y-%m-%d %H:%M");
+        if (iss.fail()) return false;
+        std::time_t t = std::mktime(&tm);
+        out_ms = static_cast<std::int64_t>(t) * 1000;
+        return true;
+    };
+
+    if (ImGui::BeginTable("JournalTable", 6, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
         ImGui::TableSetupColumn("Symbol");
         ImGui::TableSetupColumn("Side");
         ImGui::TableSetupColumn("Price");
         ImGui::TableSetupColumn("Qty");
         ImGui::TableSetupColumn("Time");
+        ImGui::TableSetupColumn("Actions");
         ImGui::TableHeadersRow();
-        for (const auto& e : journal.entries()) {
+        auto& entries = journal.entries();
+        for (size_t i = 0; i < entries.size(); ++i) {
+            auto& e = entries[i];
             ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0); ImGui::Text("%s", e.symbol.c_str());
-            ImGui::TableSetColumnIndex(1); ImGui::Text("%s", Journal::side_to_string(e.side));
-            ImGui::TableSetColumnIndex(2); ImGui::Text("%.2f", e.price);
-            ImGui::TableSetColumnIndex(3); ImGui::Text("%.4f", e.quantity);
-            ImGui::TableSetColumnIndex(4); ImGui::Text("%lld", (long long)e.timestamp);
+            if (edit_index == static_cast<int>(i)) {
+                ImGui::TableSetColumnIndex(0); ImGui::InputText("##sym", edit_symbol, sizeof(edit_symbol));
+                ImGui::TableSetColumnIndex(1); ImGui::Combo("##side", &edit_side, "BUY\0SELL\0");
+                ImGui::TableSetColumnIndex(2); ImGui::InputDouble("##price", &edit_price, 0, 0, "%.2f");
+                ImGui::TableSetColumnIndex(3); ImGui::InputDouble("##qty", &edit_qty, 0, 0, "%.4f");
+                ImGui::TableSetColumnIndex(4); ImGui::InputText("##time", edit_time, sizeof(edit_time));
+                ImGui::TableSetColumnIndex(5);
+                if (ImGui::Button(("Save##" + std::to_string(i)).c_str())) {
+                    e.symbol = edit_symbol;
+                    e.side = edit_side == 0 ? Journal::Side::Buy : Journal::Side::Sell;
+                    e.price = edit_price;
+                    e.quantity = edit_qty;
+                    std::int64_t ms;
+                    if (parse_timestamp(edit_time, ms)) {
+                        e.timestamp = ms;
+                    }
+                    edit_index = -1;
+                }
+                ImGui::SameLine();
+                if (ImGui::Button(("Cancel##" + std::to_string(i)).c_str())) {
+                    edit_index = -1;
+                }
+            } else {
+                ImGui::TableSetColumnIndex(0); ImGui::Text("%s", e.symbol.c_str());
+                ImGui::TableSetColumnIndex(1); ImGui::Text("%s", Journal::side_to_string(e.side));
+                ImGui::TableSetColumnIndex(2); ImGui::Text("%.2f", e.price);
+                ImGui::TableSetColumnIndex(3); ImGui::Text("%.4f", e.quantity);
+                ImGui::TableSetColumnIndex(4); ImGui::Text("%s", format_timestamp(e.timestamp).c_str());
+                ImGui::TableSetColumnIndex(5);
+                if (ImGui::Button(("Edit##" + std::to_string(i)).c_str())) {
+                    edit_index = static_cast<int>(i);
+                    std::strncpy(edit_symbol, e.symbol.c_str(), sizeof(edit_symbol));
+                    edit_symbol[sizeof(edit_symbol) - 1] = '\0';
+                    edit_side = e.side == Journal::Side::Buy ? 0 : 1;
+                    edit_price = e.price;
+                    edit_qty = e.quantity;
+                    std::string ts = format_timestamp(e.timestamp);
+                    std::strncpy(edit_time, ts.c_str(), sizeof(edit_time));
+                    edit_time[sizeof(edit_time) - 1] = '\0';
+                }
+                ImGui::SameLine();
+                if (ImGui::Button(("Delete##" + std::to_string(i)).c_str())) {
+                    entries.erase(entries.begin() + i);
+                    --i;
+                }
+            }
         }
         ImGui::EndTable();
     }


### PR DESCRIPTION
## Summary
- Format journal timestamps for display using `YYYY-MM-DD HH:MM`
- Enable editing and deleting journal entries directly from the ImGui table
- Parse edited timestamps back to milliseconds before saving

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689dff8ef6c88327af0d7b55f65ca4f3