### PR TITLE
Add configurable logging features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "data_dir": "candle_data",
-  "pairs": []
+  "pairs": [],
+  "log_level": "INFO"
 }

--- a/include/config.h
+++ b/include/config.h
@@ -5,9 +5,12 @@
 
 // Configuration file, can be expanded later
 
+enum class LogLevel;
+
 namespace Config {
 
 std::vector<std::string> load_selected_pairs(const std::string& filename);
 void save_selected_pairs(const std::string& filename, const std::vector<std::string>& pairs);
+LogLevel load_min_log_level(const std::string& filename);
 
 } // namespace Config

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -32,6 +32,9 @@ using namespace Core;
 
 int App::run() {
   // Init GLFW
+  auto level = Config::load_min_log_level("config.json");
+  Logger::instance().set_min_level(level);
+  Logger::instance().enable_console_output(true);
   Logger::instance().set_file("terminal.log");
   Logger::instance().info("Application started");
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "logger.h"
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <iostream>
@@ -26,14 +27,45 @@ std::vector<std::string> load_selected_pairs(const std::string& filename) {
 }
 
 void save_selected_pairs(const std::string& filename, const std::vector<std::string>& pairs) {
+    nlohmann::json j;
+    {
+        std::ifstream in(filename);
+        if (in.is_open()) {
+            try {
+                in >> j;
+            } catch (...) {
+            }
+        }
+    }
+    j["pairs"] = pairs;
     std::ofstream out(filename);
     if (out.is_open()) {
-        nlohmann::json j;
-        j["pairs"] = pairs;
         out << j.dump(4);
     } else {
         std::cerr << "Failed to open " << filename << " for writing" << std::endl;
     }
+}
+
+LogLevel load_min_log_level(const std::string& filename) {
+    std::ifstream in(filename);
+    if (in.is_open()) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            if (j.contains("log_level") && j["log_level"].is_string()) {
+                std::string level = j["log_level"].get<std::string>();
+                if (level == "INFO")
+                    return LogLevel::Info;
+                if (level == "WARN" || level == "WARNING")
+                    return LogLevel::Warning;
+                if (level == "ERROR")
+                    return LogLevel::Error;
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to parse config.json: " << e.what() << std::endl;
+        }
+    }
+    return LogLevel::Info;
 }
 
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -2,18 +2,58 @@
 
 #include <chrono>
 #include <ctime>
+#include <filesystem>
 #include <iomanip>
+#include <iostream>
+#include <sstream>
 
 Logger &Logger::instance() {
   static Logger inst;
   return inst;
 }
 
-void Logger::set_file(const std::string &filename) {
+void Logger::set_file(const std::string &filename, std::size_t max_size) {
   std::lock_guard<std::mutex> lock(mutex_);
+  filename_ = filename;
+  max_file_size_ = max_size;
+  namespace fs = std::filesystem;
   if (out_.is_open())
     out_.close();
+  bool rotate = false;
+  if (fs::exists(filename)) {
+    auto size = fs::file_size(filename);
+    auto last = fs::last_write_time(filename);
+    auto last_sys = decltype(last)::clock::to_sys(last);
+    auto now = std::chrono::system_clock::now();
+    auto today = std::chrono::time_point_cast<std::chrono::days>(now);
+    auto file_day =
+        std::chrono::time_point_cast<std::chrono::days>(last_sys);
+    if (size >= max_file_size_ || file_day != today)
+      rotate = true;
+  }
+  if (rotate) {
+    auto t = std::time(nullptr);
+    std::tm tm;
+#if defined(_WIN32)
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    std::ostringstream oss;
+    oss << filename << '.' << std::put_time(&tm, "%Y%m%d%H%M%S");
+    fs::rename(filename, oss.str());
+  }
   out_.open(filename, std::ios::app);
+}
+
+void Logger::enable_console_output(bool enable) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  console_output_ = enable;
+}
+
+void Logger::set_min_level(LogLevel level) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  min_level_ = level;
 }
 
 std::string Logger::level_to_string(LogLevel level) {
@@ -29,6 +69,8 @@ std::string Logger::level_to_string(LogLevel level) {
 }
 
 void Logger::log(LogLevel level, const std::string &message) {
+  if (static_cast<int>(level) < static_cast<int>(min_level_))
+    return;
   using namespace std::chrono;
   auto now = system_clock::now();
   auto t = system_clock::to_time_t(now);
@@ -39,10 +81,14 @@ void Logger::log(LogLevel level, const std::string &message) {
 #else
   localtime_r(&t, &tm);
 #endif
-  if (out_.is_open()) {
-    out_ << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " ["
-         << level_to_string(level) << "] " << message << std::endl;
-  }
+  std::ostringstream oss;
+  oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " ["
+      << level_to_string(level) << "] " << message << std::endl;
+  auto formatted = oss.str();
+  if (out_.is_open())
+    out_ << formatted;
+  if (console_output_)
+    std::cout << formatted;
 }
 
 void Logger::info(const std::string &message) { log(LogLevel::Info, message); }

--- a/src/logger.h
+++ b/src/logger.h
@@ -9,7 +9,10 @@ enum class LogLevel { Info, Warning, Error };
 class Logger {
 public:
   static Logger &instance();
-  void set_file(const std::string &filename);
+  void set_file(const std::string &filename,
+                std::size_t max_size = 1024 * 1024);
+  void enable_console_output(bool enable);
+  void set_min_level(LogLevel level);
   void log(LogLevel level, const std::string &message);
   void info(const std::string &message);
   void warn(const std::string &message);
@@ -19,6 +22,10 @@ private:
   Logger() = default;
   std::ofstream out_;
   std::mutex mutex_;
+  bool console_output_ = false;
+  LogLevel min_level_ = LogLevel::Info;
+  std::string filename_;
+  std::size_t max_file_size_ = 1024 * 1024;
   std::string level_to_string(LogLevel level);
 };
 


### PR DESCRIPTION
## Summary
- allow logger to mirror output to stdout with thread safety
- rotate log file by size or date when setting file
- read minimum log level from config.json and honor it

## Testing
- `cmake -DBUILD_TRADING_TERMINAL=OFF ..`
- `cmake --build . -j 4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689f1dcc93508327ab2bcf8cf74790b5