### PR TITLE
Cache signals and format timestamps

### DIFF
--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -1,7 +1,13 @@
+// Caches previously computed signals to avoid recalculation when parameters
+// have not changed.
+
 #include "ui/signals_window.h"
 
 #include "imgui.h"
 #include "signal.h"
+
+#include <algorithm>
+#include <ctime>
 
 using namespace Core;
 
@@ -25,30 +31,69 @@ void DrawSignalsWindow(
     }
     ImGui::Checkbox("Show on Chart", &show_on_chart);
 
-    signal_entries.clear();
-    buy_times.clear();
-    buy_prices.clear();
-    sell_times.clear();
-    sell_prices.clear();
+    struct SignalsCache {
+        int short_period = 0;
+        int long_period = 0;
+        std::string active_pair;
+        std::string selected_interval;
+        long long last_candle_time = 0;
+        std::vector<SignalEntry> entries;
+        std::vector<double> buy_times;
+        std::vector<double> buy_prices;
+        std::vector<double> sell_times;
+        std::vector<double> sell_prices;
+        bool initialized = false;
+    };
+    static SignalsCache cache;
 
     const auto& sig_candles = all_candles.at(active_pair).at(selected_interval);
-    for (std::size_t i = static_cast<std::size_t>(long_period); i < sig_candles.size(); ++i) {
-        int sig = Signal::sma_crossover_signal(sig_candles, i, short_period, long_period);
-        if (sig != 0) {
-            double t = static_cast<double>(sig_candles[i].open_time) / 1000.0;
-            double price = sig_candles[i].close;
-            double short_sma = Signal::simple_moving_average(sig_candles, i, short_period);
-            double long_sma = Signal::simple_moving_average(sig_candles, i, long_period);
-            signal_entries.push_back({t, price, short_sma, long_sma, sig});
-            if (sig > 0) {
-                buy_times.push_back(t);
-                buy_prices.push_back(price);
-            } else {
-                sell_times.push_back(t);
-                sell_prices.push_back(price);
+    long long latest_time = sig_candles.empty() ? 0 : sig_candles.back().open_time;
+
+    bool need_recalc = !cache.initialized || cache.short_period != short_period ||
+                       cache.long_period != long_period ||
+                       cache.active_pair != active_pair ||
+                       cache.selected_interval != selected_interval ||
+                       cache.last_candle_time != latest_time;
+
+    if (need_recalc) {
+        cache.short_period = short_period;
+        cache.long_period = long_period;
+        cache.active_pair = active_pair;
+        cache.selected_interval = selected_interval;
+        cache.last_candle_time = latest_time;
+
+        cache.entries.clear();
+        cache.buy_times.clear();
+        cache.buy_prices.clear();
+        cache.sell_times.clear();
+        cache.sell_prices.clear();
+
+        for (std::size_t i = static_cast<std::size_t>(long_period); i < sig_candles.size(); ++i) {
+            int sig = Signal::sma_crossover_signal(sig_candles, i, short_period, long_period);
+            if (sig != 0) {
+                double t = static_cast<double>(sig_candles[i].open_time) / 1000.0;
+                double price = sig_candles[i].close;
+                double short_sma = Signal::simple_moving_average(sig_candles, i, short_period);
+                double long_sma = Signal::simple_moving_average(sig_candles, i, long_period);
+                cache.entries.push_back({t, price, short_sma, long_sma, sig});
+                if (sig > 0) {
+                    cache.buy_times.push_back(t);
+                    cache.buy_prices.push_back(price);
+                } else {
+                    cache.sell_times.push_back(t);
+                    cache.sell_prices.push_back(price);
+                }
             }
         }
+
+        cache.initialized = true;
     }
+
+    signal_entries = cache.entries;
+    buy_times = cache.buy_times;
+    buy_prices = cache.buy_prices;
+    sell_times = cache.sell_times;
+    sell_prices = cache.sell_prices;
 
     if (ImGui::BeginTable("SignalsTable", 4, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
         ImGui::TableSetupColumn("Time");
@@ -58,10 +103,17 @@ void DrawSignalsWindow(
         ImGui::TableHeadersRow();
         int rows = static_cast<int>(signal_entries.size());
         int start = std::max(0, rows - 10);
+        char buf[20];
         for (int i = start; i < rows; ++i) {
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
-            ImGui::Text("%lld", (long long)signal_entries[i].time);
+            std::time_t tt = static_cast<std::time_t>(signal_entries[i].time);
+            std::tm* tm = std::localtime(&tt);
+            if (tm && std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", tm)) {
+                ImGui::TextUnformatted(buf);
+            } else {
+                ImGui::Text("%lld", static_cast<long long>(signal_entries[i].time));
+            }
             ImGui::TableSetColumnIndex(1);
             ImGui::Text("%.2f", signal_entries[i].short_sma);
             ImGui::TableSetColumnIndex(2);


### PR DESCRIPTION
## Summary
- cache generated signals and track parameters to avoid unnecessary recalculations
- refresh signals table from cache and display timestamps in date/time format

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689f1f5725948327b65cb3f9155773a7