### PR TITLE
Use clock_cast for filesystem timestamp conversion

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -23,7 +23,8 @@ void Logger::set_file(const std::string &filename, std::size_t max_size) {
   if (fs::exists(filename)) {
     auto size = fs::file_size(filename);
     auto last = fs::last_write_time(filename);
-    auto last_sys = decltype(last)::clock::to_sys(last);
+    auto last_sys =
+        std::chrono::clock_cast<std::chrono::system_clock>(last);
     auto now = std::chrono::system_clock::now();
     auto today = std::chrono::time_point_cast<std::chrono::days>(now);
     auto file_day =


### PR DESCRIPTION
## Summary
- Replace `decltype(last)::clock::to_sys(last)` with `std::chrono::clock_cast<std::chrono::system_clock>(last)` in `Logger::set_file`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*
- `g++ -std=c++20 -I./src -c src/logger.cpp`
- `clang++ -std=c++20 -I./src -c src/logger.cpp`


------
https://chatgpt.com/codex/tasks/task_e_689f50d278ac8327b94319c314732cd1