### PR TITLE
Add sequential kline fetching and dynamic candle limit

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "data_dir": "candle_data",
   "pairs": [],
-  "log_level": "INFO"
+  "log_level": "INFO",
+  "candles_limit": 5000
 }

--- a/include/config.h
+++ b/include/config.h
@@ -12,5 +12,6 @@ namespace Config {
 std::vector<std::string> load_selected_pairs(const std::string& filename);
 void save_selected_pairs(const std::string& filename, const std::vector<std::string>& pairs);
 LogLevel load_min_log_level(const std::string& filename);
+size_t load_candles_limit(const std::string& filename);
 
 } // namespace Config

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -71,6 +71,7 @@ int App::run() {
       data_service_.load_selected_pairs("config.json");
   if (pair_names.empty())
     pair_names.push_back("BTCUSDT");
+  int candles_limit = Config::load_candles_limit("config.json");
   std::vector<PairItem> pairs;
   for (const auto &name : pair_names) {
     pairs.push_back({name, true});
@@ -125,7 +126,7 @@ int App::run() {
         all_candles[pair][interval] = {};
         initial_fetches.push_back({
             pair, interval,
-            data_service_.fetch_klines_async(pair, interval, 5000)});
+            data_service_.fetch_klines_async(pair, interval, candles_limit)});
       } else {
         all_candles[pair][interval] = candles;
         ++completed_initial_fetches;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -68,4 +68,20 @@ LogLevel load_min_log_level(const std::string& filename) {
     return LogLevel::Info;
 }
 
+size_t load_candles_limit(const std::string& filename) {
+    std::ifstream in(filename);
+    if (in.is_open()) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            if (j.contains("candles_limit") && j["candles_limit"].is_number_unsigned()) {
+                return j["candles_limit"].get<size_t>();
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to parse config.json: " << e.what() << std::endl;
+        }
+    }
+    return 5000;
+}
+
 }

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 #include <mutex>
+#include <algorithm>
 
 namespace {
 std::mutex request_mutex;
@@ -22,6 +23,30 @@ void throttle(std::chrono::milliseconds pause) {
   }
   last_request = std::chrono::steady_clock::now();
 }
+
+long long interval_to_ms(const std::string &interval) {
+  if (interval.empty())
+    return 0;
+  char unit = interval.back();
+  long long value = 0;
+  try {
+    value = std::stoll(interval.substr(0, interval.size() - 1));
+  } catch (...) {
+    return 0;
+  }
+  switch (unit) {
+  case 'm':
+    return value * 60LL * 1000LL;
+  case 'h':
+    return value * 60LL * 60LL * 1000LL;
+  case 'd':
+    return value * 24LL * 60LL * 60LL * 1000LL;
+  case 'w':
+    return value * 7LL * 24LL * 60LL * 60LL * 1000LL;
+  default:
+    return 0;
+  }
+}
 } // namespace
 
 namespace Core {
@@ -30,52 +55,83 @@ KlinesResult DataFetcher::fetch_klines(
     const std::string &symbol, const std::string &interval, int limit,
     int max_retries, std::chrono::milliseconds retry_delay,
     std::chrono::milliseconds request_pause) {
-  std::string url = "https://api.binance.com/api/v3/klines?symbol=" + symbol +
-                    "&interval=" + interval + "&limit=" +
-                    std::to_string(limit);
-  for (int attempt = 0; attempt < max_retries; ++attempt) {
-    throttle(request_pause);
-    cpr::Response r = cpr::Get(cpr::Url{url});
-    if (r.error.code != cpr::ErrorCode::OK) {
-      Logger::instance().error("Request error: " + r.error.message);
+  const std::string base_url =
+      "https://api.binance.com/api/v3/klines?symbol=" + symbol +
+      "&interval=" + interval;
+  std::vector<Candle> all_candles;
+  long long interval_ms = interval_to_ms(interval);
+  auto now = std::chrono::system_clock::now();
+  long long end_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           now.time_since_epoch())
+                           .count();
+  int http_status = 0;
+
+  while (static_cast<int>(all_candles.size()) < limit) {
+    int batch_limit =
+        std::min(1000, limit - static_cast<int>(all_candles.size()));
+    long long start_time = end_time - interval_ms * batch_limit;
+    std::string url = base_url + "&startTime=" + std::to_string(start_time) +
+                      "&endTime=" + std::to_string(end_time) + "&limit=" +
+                      std::to_string(batch_limit);
+
+    bool success = false;
+    for (int attempt = 0; attempt < max_retries; ++attempt) {
+      throttle(request_pause);
+      cpr::Response r = cpr::Get(cpr::Url{url});
+      if (r.error.code != cpr::ErrorCode::OK) {
+        Logger::instance().error("Request error: " + r.error.message);
+        if (attempt < max_retries - 1) {
+          std::this_thread::sleep_for(retry_delay);
+          continue;
+        }
+        return {FetchError::NetworkError, 0, r.error.message, {}};
+      }
+      http_status = r.status_code;
+      if (r.status_code == 200) {
+        try {
+          std::vector<Candle> candles;
+          auto json_data = nlohmann::json::parse(r.text);
+          for (const auto &kline : json_data) {
+            candles.emplace_back(
+                kline[0].get<long long>(),
+                std::stod(kline[1].get<std::string>()),
+                std::stod(kline[2].get<std::string>()),
+                std::stod(kline[3].get<std::string>()),
+                std::stod(kline[4].get<std::string>()),
+                std::stod(kline[5].get<std::string>()),
+                kline[6].get<long long>(),
+                std::stod(kline[7].get<std::string>()), kline[8].get<int>(),
+                std::stod(kline[9].get<std::string>()),
+                std::stod(kline[10].get<std::string>()),
+                std::stod(kline[11].get<std::string>()));
+          }
+          if (candles.empty()) {
+            return {FetchError::None, http_status, "", all_candles};
+          }
+          all_candles.insert(all_candles.begin(), candles.begin(),
+                             candles.end());
+          end_time = candles.front().open_time - 1;
+          success = true;
+          break;
+        } catch (const std::exception &e) {
+          Logger::instance().error(std::string("Error processing kline data: ") +
+                                   e.what());
+          return {FetchError::ParseError, http_status, e.what(), {}};
+        }
+      }
+      Logger::instance().error("HTTP Request failed with status code: " +
+                               std::to_string(r.status_code));
       if (attempt < max_retries - 1) {
         std::this_thread::sleep_for(retry_delay);
-        continue;
-      }
-      return {FetchError::NetworkError, 0, r.error.message, {}};
-    }
-    if (r.status_code == 200) {
-      try {
-        std::vector<Candle> candles;
-        auto json_data = nlohmann::json::parse(r.text);
-        for (const auto &kline : json_data) {
-          candles.emplace_back(
-              kline[0].get<long long>(), std::stod(kline[1].get<std::string>()),
-              std::stod(kline[2].get<std::string>()),
-              std::stod(kline[3].get<std::string>()),
-              std::stod(kline[4].get<std::string>()),
-              std::stod(kline[5].get<std::string>()), kline[6].get<long long>(),
-              std::stod(kline[7].get<std::string>()), kline[8].get<int>(),
-              std::stod(kline[9].get<std::string>()),
-              std::stod(kline[10].get<std::string>()),
-              std::stod(kline[11].get<std::string>()));
-        }
-        return {FetchError::None, r.status_code, "", candles};
-      } catch (const std::exception &e) {
-        Logger::instance().error(std::string("Error processing kline data: ") +
-                                e.what());
-        return {FetchError::ParseError, r.status_code, e.what(), {}};
+      } else {
+        return {FetchError::HttpError, r.status_code, r.error.message, {}};
       }
     }
-    Logger::instance().error("HTTP Request failed with status code: " +
-                             std::to_string(r.status_code));
-    if (attempt < max_retries - 1) {
-      std::this_thread::sleep_for(retry_delay);
-    } else {
-      return {FetchError::HttpError, r.status_code, r.error.message, {}};
+    if (!success) {
+      return {FetchError::HttpError, http_status, "Max retries exceeded", {}};
     }
   }
-  return {FetchError::HttpError, 0, "Max retries exceeded", {}};
+  return {FetchError::None, http_status, "", all_candles};
 }
 
 std::future<KlinesResult> DataFetcher::fetch_klines_async(

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -13,7 +13,7 @@
 using namespace Core;
 
 namespace {
-constexpr size_t EXPECTED_CANDLES = 5000;
+const size_t EXPECTED_CANDLES = Config::load_candles_limit("config.json");
 constexpr size_t THRESHOLD_LOW = 100;
 constexpr size_t THRESHOLD_MED = 1000;
 
@@ -76,7 +76,7 @@ void DrawControlPanel(
       for (const auto &interval : intervals) {
         auto candles = CandleManager::load_candles(symbol, interval);
         if (candles.empty()) {
-          auto fetched = DataFetcher::fetch_klines(symbol, interval, 5000);
+          auto fetched = DataFetcher::fetch_klines(symbol, interval, EXPECTED_CANDLES);
           if (fetched.error == FetchError::None &&
               !fetched.candles.empty()) {
             candles = fetched.candles;
@@ -245,7 +245,7 @@ void DrawControlPanel(
       if (all_candles[pair][active_interval].empty()) {
         auto candles = CandleManager::load_candles(pair, active_interval);
         if (candles.empty()) {
-          auto fetched = DataFetcher::fetch_klines(pair, active_interval, 5000);
+          auto fetched = DataFetcher::fetch_klines(pair, active_interval, EXPECTED_CANDLES);
           if (fetched.error == FetchError::None &&
               !fetched.candles.empty()) {
             candles = fetched.candles;
@@ -265,7 +265,7 @@ void DrawControlPanel(
       if (all_candles[active_pair][interval].empty()) {
         auto candles = CandleManager::load_candles(active_pair, interval);
         if (candles.empty()) {
-          auto fetched = DataFetcher::fetch_klines(active_pair, interval, 5000);
+          auto fetched = DataFetcher::fetch_klines(active_pair, interval, EXPECTED_CANDLES);
           if (fetched.error == FetchError::None &&
               !fetched.candles.empty()) {
             candles = fetched.candles;


### PR DESCRIPTION
## Summary
- fetch kline data in sequential batches using start/end times
- derive candle request limit from config and use it for progress calculation
- expose candles_limit in configuration file

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689f638dce808327b421295403cb7ba8