### PR TITLE
Use high-contrast candlestick colors

### DIFF
--- a/src/plot/candlestick.h
+++ b/src/plot/candlestick.h
@@ -13,8 +13,8 @@ void PlotCandlestick(const char* label_id,
                      int count,
                      bool tooltip = true,
                      float width_percent = 0.25f,
-                     ImVec4 bullCol = ImVec4(0,1,0,1),
-                     ImVec4 bearCol = ImVec4(1,0,0,1));
+                     ImVec4 bullCol = ImVec4(1,1,1,1),
+                     ImVec4 bearCol = ImVec4(0.1f,0.1f,0.1f,1));
 
 } // namespace Plot
 

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -109,7 +109,9 @@ void DrawChartWindow(
             times.data(), opens.data(), closes.data(), lows.data(), highs.data(),
             (int)candles.size(),
             true,
-            0.25f
+            0.25f,
+            ImVec4(1,1,1,1),
+            ImVec4(0.1f,0.1f,0.1f,1)
         );
 
         ImPlotRect cur_limits = ImPlot::GetPlotLimits();


### PR DESCRIPTION
## Summary
- draw bullish candles in bright white and bearish candles in near-black
- explicitly set candlestick colors when rendering charts

## Testing
- `cmake --build build`
- `cd build && ctest --output-on-failure`
- `g++ -fsyntax-only src/ui/chart_window.cpp -Isrc -Iinclude -Ithird_party/imgui -Ithird_party/imgui/backends` *(fails: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f667c225c8327bc67e90adfa14667