### PR TITLE
Define NOMINMAX compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(TradingTerminal LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_compile_definitions(NOMINMAX)
+
 option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
 find_package(nlohmann_json CONFIG REQUIRED)


### PR DESCRIPTION
## Summary
- Globally define NOMINMAX to prevent Windows min/max macros from interfering with standard library functions.

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_689f6a784f608327ab4f15fc403a19a1