### PR TITLE
Lighten bearish candlestick color and background

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -262,7 +262,7 @@ int App::run() {
     int display_w, display_h;
     glfwGetFramebufferSize(window, &display_w, &display_h);
     glViewport(0, 0, display_w, display_h);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+    glClearColor(0.15f, 0.15f, 0.15f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     glfwSwapBuffers(window);

--- a/src/plot/candlestick.h
+++ b/src/plot/candlestick.h
@@ -14,7 +14,7 @@ void PlotCandlestick(const char* label_id,
                      bool tooltip = true,
                      float width_percent = 0.25f,
                      ImVec4 bullCol = ImVec4(1,1,1,1),
-                     ImVec4 bearCol = ImVec4(0.1f,0.1f,0.1f,1));
+                     ImVec4 bearCol = ImVec4(0.3f,0.3f,0.3f,1));
 
 } // namespace Plot
 

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -159,7 +159,7 @@ void DrawChartWindow(
             true,
             0.25f,
             ImVec4(1,1,1,1),
-            ImVec4(0.1f,0.1f,0.1f,1)
+            ImVec4(0.3f,0.3f,0.3f,1)
         );
 
         ImPlotRect cur_limits = ImPlot::GetPlotLimits();


### PR DESCRIPTION
## Summary
- Soften default bearish candlestick color to a lighter grey
- Update chart window to use the new bearish color
- Lighten application background clear color for a brighter UI

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689f6de616608327a9d060f3ebe5828d