### PR TITLE
Expand chart plot to fill window

### DIFF
--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -149,7 +149,7 @@ void DrawChartWindow(
     }
 
     ImPlotFlags plot_flags = ImPlotFlags_Crosshairs;
-    if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), ImVec2(-1,0), plot_flags)) {
+    if (ImPlot::BeginPlot(("Candles - " + active_pair).c_str(), ImGui::GetContentRegionAvail(), plot_flags)) {
         ImPlot::SetupAxes("Time", "Price");
         ImPlot::SetupLegend(ImPlotLocation_South, ImPlotLegendFlags_Outside);
         Plot::PlotCandlestick(


### PR DESCRIPTION
## Summary
- Make the chart plot occupy all available space by sizing it with ImGui::GetContentRegionAvail

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689f6f98bea4832789ae76a9d31ccfcc