### PR TITLE
Add configurable signal bot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(BUILD_TRADING_TERMINAL)
         src/journal.cpp
         src/services/data_service.cpp
         src/services/journal_service.cpp
+        src/services/signal_bot.cpp
         src/ui/control_panel.cpp
         src/ui/signals_window.cpp
         src/ui/analytics_window.cpp
@@ -104,14 +105,18 @@ add_executable(test_signal
     tests/test_signal.cpp
     src/signal.cpp
     src/candle.cpp
+    src/services/signal_bot.cpp
+    src/config.cpp
 )
 
 target_include_directories(test_signal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_link_libraries(test_signal PRIVATE
     GTest::gtest_main
+    nlohmann_json::nlohmann_json
 )
 
 add_test(NAME test_signal COMMAND test_signal)

--- a/config.json
+++ b/config.json
@@ -2,5 +2,10 @@
   "data_dir": "candle_data",
   "pairs": [],
   "log_level": "INFO",
-  "candles_limit": 5000
+  "candles_limit": 5000,
+  "signal": {
+    "type": "sma_crossover",
+    "short_period": 2,
+    "long_period": 3
+  }
 }

--- a/include/config.h
+++ b/include/config.h
@@ -14,4 +14,12 @@ void save_selected_pairs(const std::string& filename, const std::vector<std::str
 LogLevel load_min_log_level(const std::string& filename);
 size_t load_candles_limit(const std::string& filename);
 
+struct SignalConfig {
+    std::string type{"sma_crossover"};
+    std::size_t short_period{0};
+    std::size_t long_period{0};
+};
+
+SignalConfig load_signal_config(const std::string& filename);
+
 } // namespace Config

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -84,4 +84,31 @@ size_t load_candles_limit(const std::string& filename) {
     return 5000;
 }
 
+SignalConfig load_signal_config(const std::string& filename) {
+    std::ifstream in(filename);
+    SignalConfig cfg;
+    if (in.is_open()) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            if (j.contains("signal") && j["signal"].is_object()) {
+                const auto& s = j["signal"];
+                if (s.contains("type") && s["type"].is_string()) {
+                    cfg.type = s["type"].get<std::string>();
+                }
+                if (s.contains("short_period") && s["short_period"].is_number_unsigned()) {
+                    cfg.short_period = s["short_period"].get<std::size_t>();
+                }
+                if (s.contains("long_period") && s["long_period"].is_number_unsigned()) {
+                    cfg.long_period = s["long_period"].get<std::size_t>();
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to parse config.json: " << e.what() << std::endl;
+        }
+    }
+    return cfg;
 }
+
+} // namespace Config
+

--- a/src/services/signal_bot.cpp
+++ b/src/services/signal_bot.cpp
@@ -1,0 +1,19 @@
+#include "services/signal_bot.h"
+
+SignalBot::SignalBot(const Config::SignalConfig& cfg) : cfg_(cfg) {}
+
+void SignalBot::set_config(const Config::SignalConfig& cfg) {
+    cfg_ = cfg;
+}
+
+const Config::SignalConfig& SignalBot::config() const noexcept {
+    return cfg_;
+}
+
+int SignalBot::generate_signal(const std::vector<Core::Candle>& candles, size_t index) {
+    if (cfg_.type == "sma_crossover") {
+        return Signal::sma_crossover_signal(candles, index, cfg_.short_period, cfg_.long_period);
+    }
+    return 0;
+}
+

--- a/src/services/signal_bot.h
+++ b/src/services/signal_bot.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+#include "config.h"
+#include "core/backtester.h"
+#include "signal.h"
+
+// SignalBot wraps signal generation based on configurable settings.
+// It implements Core::IStrategy so it can be used with the backtester
+// or real-time trading modules.
+class SignalBot : public Core::IStrategy {
+public:
+    explicit SignalBot(const Config::SignalConfig& cfg);
+
+    void set_config(const Config::SignalConfig& cfg);
+    [[nodiscard]] const Config::SignalConfig& config() const noexcept;
+
+    int generate_signal(const std::vector<Core::Candle>& candles, size_t index) override;
+
+private:
+    Config::SignalConfig cfg_;
+};
+

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -1,5 +1,9 @@
 #include "signal.h"
+#include "services/signal_bot.h"
+#include "config.h"
 #include <vector>
+#include <fstream>
+#include <filesystem>
 #include <gtest/gtest.h>
 
 TEST(SignalTest, SmaCrossoverAndAverage) {
@@ -18,5 +22,36 @@ TEST(SignalTest, SmaCrossoverAndAverage) {
 
     double sma = Signal::simple_moving_average(candles,7,3);
     EXPECT_NEAR(sma, 3.0, 1e-9);
+}
+
+TEST(SignalBotTest, GeneratesSignalFromConfig) {
+    std::vector<Core::Candle> candles;
+    double closes[] = {5,4,3,2,3,4};
+    for (int i = 0; i < 6; ++i) {
+        candles.emplace_back(i,0,0,0,closes[i],0,0,0,0,0,0,0);
+    }
+    Config::SignalConfig cfg{ "sma_crossover", 2, 3 };
+    SignalBot bot(cfg);
+    int sig = bot.generate_signal(candles,5);
+    EXPECT_EQ(sig, 1);
+}
+
+TEST(ConfigTest, LoadSignalConfig) {
+    std::filesystem::path tmp = std::filesystem::temp_directory_path() / "signal_config_test.json";
+    {
+        std::ofstream out(tmp);
+        out << R"({
+  "signal": {
+    "type": "sma_crossover",
+    "short_period": 2,
+    "long_period": 3
+  }
+})";
+    }
+    Config::SignalConfig cfg = Config::load_signal_config(tmp.string());
+    EXPECT_EQ(cfg.type, "sma_crossover");
+    EXPECT_EQ(cfg.short_period, 2u);
+    EXPECT_EQ(cfg.long_period, 3u);
+    std::filesystem::remove(tmp);
 }
 


### PR DESCRIPTION
## Summary
- add configurable `SignalBot` implementing Core::IStrategy for future signal algorithms
- extend configuration with `SignalConfig` and loader from `config.json`
- cover signal bot and configuration with new tests and build updates

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689f769115f4832790065753329e9903