### PR TITLE
Remove pair and interval controls from control panel

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -201,9 +201,9 @@ int App::run() {
       ImGui::End();
     }
 
-    DrawControlPanel(pairs, selected_pairs, active_pair, active_interval,
-                     intervals, selected_interval, all_candles, save_pairs,
-                     exchange_pairs);
+      DrawControlPanel(pairs, selected_pairs, active_pair, intervals,
+                       selected_interval, all_candles, save_pairs,
+                       exchange_pairs);
 
     DrawSignalsWindow(short_period, long_period, show_on_chart, signal_entries,
                       buy_times, buy_prices, sell_times, sell_prices,

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -16,7 +16,6 @@ void DrawControlPanel(
     std::vector<PairItem>& pairs,
     std::vector<std::string>& selected_pairs,
     std::string& active_pair,
-    std::string& active_interval,
     const std::vector<std::string>& intervals,
     std::string& selected_interval,
     std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,


### PR DESCRIPTION
## Summary
- drop pair/interval selection UI from control panel to centralize these controls
- adjust function signatures and call sites after removing active_interval parameter

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "imgui")*

------
https://chatgpt.com/codex/tasks/task_e_689f88cc3f708327ba83f28e674a918a