### PR TITLE
Fix undefined variable in control panel

### DIFF
--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -46,7 +46,6 @@ void DrawControlPanel(
     const std::vector<std::string> &exchange_pairs,
     const AppStatus &status) {
   ImGui::Begin("Control Panel");
-  (void)active_interval;
 
   ImGui::Text("Select pairs to load:");
   static std::string load_error;


### PR DESCRIPTION
## Summary
- remove leftover reference to `active_interval` in control panel UI

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "imgui")*


------
https://chatgpt.com/codex/tasks/task_e_689f9764c884832796f86a5170a761e0