### PR TITLE
Support sub-minute intervals

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -35,6 +35,8 @@ long long interval_to_ms(const std::string &interval) {
     return 0;
   }
   switch (unit) {
+  case 's':
+    return value * 1000LL;
   case 'm':
     return value * 60LL * 1000LL;
   case 'h':


### PR DESCRIPTION
## Summary
- handle second-based intervals in `interval_to_ms`
- add 3m/15s/5s options and compute update period from active interval
- use active interval for periodic klines refresh

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "imgui")*


------
https://chatgpt.com/codex/tasks/task_e_689fa073ec0083279349afe8fa23c1f1