### PR TITLE
Add EMA/RSI indicators and strategy selection UI

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 // Configuration file, can be expanded later
 
@@ -18,6 +19,7 @@ struct SignalConfig {
     std::string type{"sma_crossover"};
     std::size_t short_period{0};
     std::size_t long_period{0};
+    std::map<std::string, double> params{};
 };
 
 SignalConfig load_signal_config(const std::string& filename);

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -152,6 +152,7 @@ int App::run() {
 
   // Prepare candle storage by pair and interval
   std::string selected_interval = intervals.empty() ? "1m" : intervals[0];
+  std::string strategy = "sma_crossover";
   int short_period = 9;
   int long_period = 21;
   bool show_on_chart = false;
@@ -290,7 +291,7 @@ int App::run() {
                      selected_interval, all_candles, save_pairs,
                      exchange_pairs, status_);
 
-    DrawSignalsWindow(short_period, long_period, show_on_chart, signal_entries,
+    DrawSignalsWindow(strategy, short_period, long_period, show_on_chart, signal_entries,
                       buy_times, buy_prices, sell_times, sell_prices,
                       all_candles, active_pair, selected_interval, status_);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -102,6 +102,13 @@ SignalConfig load_signal_config(const std::string& filename) {
                 if (s.contains("long_period") && s["long_period"].is_number_unsigned()) {
                     cfg.long_period = s["long_period"].get<std::size_t>();
                 }
+                if (s.contains("params") && s["params"].is_object()) {
+                    for (auto it = s["params"].begin(); it != s["params"].end(); ++it) {
+                        if (it.value().is_number()) {
+                            cfg.params[it.key()] = it.value().get<double>();
+                        }
+                    }
+                }
             }
         } catch (const std::exception& e) {
             std::cerr << "Failed to parse config.json: " << e.what() << std::endl;

--- a/src/services/signal_bot.cpp
+++ b/src/services/signal_bot.cpp
@@ -13,6 +13,34 @@ const Config::SignalConfig& SignalBot::config() const noexcept {
 int SignalBot::generate_signal(const std::vector<Core::Candle>& candles, size_t index) {
     if (cfg_.type == "sma_crossover") {
         return Signal::sma_crossover_signal(candles, index, cfg_.short_period, cfg_.long_period);
+    } else if (cfg_.type == "ema") {
+        std::size_t period = cfg_.short_period;
+        if (period == 0) {
+            auto it = cfg_.params.find("period");
+            if (it != cfg_.params.end()) {
+                period = static_cast<std::size_t>(it->second);
+            }
+        }
+        return Signal::ema_signal(candles, index, period);
+    } else if (cfg_.type == "rsi") {
+        std::size_t period = cfg_.short_period;
+        if (period == 0) {
+            auto it = cfg_.params.find("period");
+            if (it != cfg_.params.end()) {
+                period = static_cast<std::size_t>(it->second);
+            }
+        }
+        double oversold = 30.0;
+        double overbought = 70.0;
+        auto it_os = cfg_.params.find("oversold");
+        if (it_os != cfg_.params.end()) {
+            oversold = it_os->second;
+        }
+        auto it_ob = cfg_.params.find("overbought");
+        if (it_ob != cfg_.params.end()) {
+            overbought = it_ob->second;
+        }
+        return Signal::rsi_signal(candles, index, period, oversold, overbought);
     }
     return 0;
 }

--- a/src/signal.h
+++ b/src/signal.h
@@ -16,5 +16,27 @@ namespace Signal {
                                        std::size_t short_period,
                                        std::size_t long_period);
 
+// Calculates exponential moving average of candle close prices.
+[[nodiscard]] double exponential_moving_average(const std::vector<Core::Candle>& candles,
+                                               std::size_t index,
+                                               std::size_t period);
+
+// Generates signal based on price crossing EMA.
+[[nodiscard]] int ema_signal(const std::vector<Core::Candle>& candles,
+                             std::size_t index,
+                             std::size_t period);
+
+// Calculates Relative Strength Index.
+[[nodiscard]] double relative_strength_index(const std::vector<Core::Candle>& candles,
+                                             std::size_t index,
+                                             std::size_t period);
+
+// Generates signal based on RSI thresholds.
+[[nodiscard]] int rsi_signal(const std::vector<Core::Candle>& candles,
+                             std::size_t index,
+                             std::size_t period,
+                             double oversold,
+                             double overbought);
+
 } // namespace Signal
 

--- a/src/ui/signals_window.h
+++ b/src/ui/signals_window.h
@@ -10,12 +10,13 @@
 struct SignalEntry {
     double time;
     double price;
-    double short_sma;
-    double long_sma;
+    double value1;
+    double value2;
     int type;
 };
 
 void DrawSignalsWindow(
+    std::string& strategy,
     int& short_period,
     int& long_period,
     bool& show_on_chart,

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -55,3 +55,15 @@ TEST(ConfigTest, LoadSignalConfig) {
     std::filesystem::remove(tmp);
 }
 
+TEST(SignalIndicators, CalculatesEmaAndRsi) {
+    std::vector<Core::Candle> candles;
+    double closes[] = {1,2,3,4,5};
+    for (int i = 0; i < 5; ++i) {
+        candles.emplace_back(i,0,0,0,closes[i],0,0,0,0,0,0,0);
+    }
+    double ema = Signal::exponential_moving_average(candles,4,3);
+    EXPECT_NEAR(ema, 4.25, 1e-2);
+    double rsi = Signal::relative_strength_index(candles,4,3);
+    EXPECT_NEAR(rsi, 100.0, 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- Allow strategies to define custom numeric parameters via `SignalConfig::params`
- Implement EMA and RSI indicators with corresponding signal functions and dispatch logic
- Extend signals window with strategy dropdown, parameter inputs and manual signal requests
- Cover indicator calculations with new tests

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_689fa2b29fa08327936c35002111fb5e