### PR TITLE
Use SignalBot in backtester

### DIFF
--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -15,6 +15,8 @@ void DrawSignalsWindow(
     std::string& strategy,
     int& short_period,
     int& long_period,
+    double& oversold,
+    double& overbought,
     bool& show_on_chart,
     std::vector<SignalEntry>& signal_entries,
     std::vector<double>& buy_times,
@@ -32,9 +34,6 @@ void DrawSignalsWindow(
     else if (strategy == "rsi") strategy_idx = 2;
     ImGui::Combo("Strategy", &strategy_idx, strategies, IM_ARRAYSIZE(strategies));
     strategy = strategies[strategy_idx];
-
-    static double oversold = 30.0;
-    static double overbought = 70.0;
 
     if (strategy == "sma_crossover") {
         ImGui::InputInt("Short SMA", &short_period);

--- a/src/ui/signals_window.h
+++ b/src/ui/signals_window.h
@@ -19,6 +19,8 @@ void DrawSignalsWindow(
     std::string& strategy,
     int& short_period,
     int& long_period,
+    double& oversold,
+    double& overbought,
     bool& show_on_chart,
     std::vector<SignalEntry>& signal_entries,
     std::vector<double>& buy_times,


### PR DESCRIPTION
## Summary
- Backtests now use the same signal configuration as the Signals window via SignalBot
- Expose RSI oversold/overbought parameters to allow consistent backtests
- Show chosen strategy and its parameters in the backtest results

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689fd39d31688327ae11d3f52860b476