### PR TITLE
Add RSI and MACD indicator plotting

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -116,5 +116,37 @@ int rsi_signal(const std::vector<Core::Candle>& candles,
     return 0;
 }
 
+MACDResult macd(const std::vector<Core::Candle>& candles,
+                std::size_t index,
+                std::size_t short_period,
+                std::size_t long_period,
+                std::size_t signal_period) {
+    if (short_period == 0 || long_period == 0 || signal_period == 0 ||
+        short_period >= long_period) {
+        return {0.0, 0.0, 0.0};
+    }
+    if (index >= candles.size() ||
+        index + 1 < long_period + signal_period - 1) {
+        return {0.0, 0.0, 0.0};
+    }
+    std::vector<double> macd_vals;
+    for (std::size_t i = long_period - 1; i <= index; ++i) {
+        double ema_short = exponential_moving_average(candles, i, short_period);
+        double ema_long = exponential_moving_average(candles, i, long_period);
+        macd_vals.push_back(ema_short - ema_long);
+    }
+    const double k = 2.0 / (static_cast<double>(signal_period) + 1.0);
+    double signal = std::accumulate(macd_vals.begin(),
+                                    macd_vals.begin() + static_cast<long>(signal_period),
+                                    0.0) /
+                    static_cast<double>(signal_period);
+    for (std::size_t i = signal_period; i < macd_vals.size(); ++i) {
+        signal = (macd_vals[i] - signal) * k + signal;
+    }
+    double macd_line = macd_vals.back();
+    double histogram = macd_line - signal;
+    return {macd_line, signal, histogram};
+}
+
 } // namespace Signal
 

--- a/src/signal.h
+++ b/src/signal.h
@@ -38,5 +38,18 @@ namespace Signal {
                              double oversold,
                              double overbought);
 
+struct MACDResult {
+    double macd;
+    double signal;
+    double histogram;
+};
+
+// Calculates Moving Average Convergence Divergence.
+[[nodiscard]] MACDResult macd(const std::vector<Core::Candle>& candles,
+                             std::size_t index,
+                             std::size_t short_period,
+                             std::size_t long_period,
+                             std::size_t signal_period);
+
 } // namespace Signal
 

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -67,3 +67,14 @@ TEST(SignalIndicators, CalculatesEmaAndRsi) {
     EXPECT_NEAR(rsi, 100.0, 1e-6);
 }
 
+TEST(SignalIndicators, CalculatesMacd) {
+    std::vector<Core::Candle> candles;
+    for (int i = 1; i <= 50; ++i) {
+        candles.emplace_back(i,0,0,0,i,0,0,0,0,0,0,0);
+    }
+    auto m = Signal::macd(candles, 49, 12, 26, 9);
+    EXPECT_NEAR(m.macd, 5.1017391484568435, 1e-6);
+    EXPECT_NEAR(m.signal, 5.107024691973398, 1e-6);
+    EXPECT_NEAR(m.histogram, -0.005285543516554192, 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- Add MACD helper returning line, signal, and histogram values
- Allow RSI and MACD overlays via new toggles and dynamic subplots in chart window
- Cover MACD calculation with unit test

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a064b546b08327874768e81c94404d