### PR TITLE
Add RSI and MACD indicators

### DIFF
--- a/src/signal.h
+++ b/src/signal.h
@@ -38,5 +38,25 @@ namespace Signal {
                              double oversold,
                              double overbought);
 
+// Calculates the MACD line (EMA(fast) - EMA(slow)).
+[[nodiscard]] double macd(const std::vector<Core::Candle>& candles,
+                          std::size_t index,
+                          std::size_t fast_period,
+                          std::size_t slow_period);
+
+// Calculates the signal line of MACD (EMA of MACD values).
+[[nodiscard]] double macd_signal(const std::vector<Core::Candle>& candles,
+                                std::size_t index,
+                                std::size_t fast_period,
+                                std::size_t slow_period,
+                                std::size_t signal_period);
+
+// Calculates the MACD histogram (MACD - signal).
+[[nodiscard]] double macd_histogram(const std::vector<Core::Candle>& candles,
+                                   std::size_t index,
+                                   std::size_t fast_period,
+                                   std::size_t slow_period,
+                                   std::size_t signal_period);
+
 } // namespace Signal
 


### PR DESCRIPTION
## Summary
- add MACD helper functions to signal utilities
- expose RSI and MACD toggles in chart window with dedicated plots

## Testing
- `cmake .. -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a064b53bb88327bffa6ee613cd4b9c