### PR TITLE
Fetch exchange intervals and merge with defaults

### DIFF
--- a/src/core/data_fetcher.h
+++ b/src/core/data_fetcher.h
@@ -30,6 +30,13 @@ struct SymbolsResult {
   std::vector<std::string> symbols;
 };
 
+struct IntervalsResult {
+  FetchError error{FetchError::None};
+  int http_status{0};
+  std::string message;
+  std::vector<std::string> intervals;
+};
+
 class DataFetcher {
 public:
   // Fetches kline (candle) data from a specified API (e.g., Binance).
@@ -67,6 +74,13 @@ public:
                         std::chrono::milliseconds(1000),
                     std::chrono::milliseconds request_pause =
                         std::chrono::milliseconds(1100));
+
+  static IntervalsResult
+  fetch_all_intervals(int max_retries = 3,
+                      std::chrono::milliseconds retry_delay =
+                          std::chrono::milliseconds(1000),
+                      std::chrono::milliseconds request_pause =
+                          std::chrono::milliseconds(1100));
 };
 
 } // namespace Core

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -21,6 +21,13 @@ Core::SymbolsResult DataService::fetch_all_symbols(
                                              request_pause);
 }
 
+Core::IntervalsResult DataService::fetch_intervals(
+    int max_retries, std::chrono::milliseconds retry_delay,
+    std::chrono::milliseconds request_pause) const {
+  return Core::DataFetcher::fetch_all_intervals(max_retries, retry_delay,
+                                               request_pause);
+}
+
 Core::KlinesResult DataService::fetch_klines(
     const std::string &symbol, const std::string &interval, int limit,
     int max_retries, std::chrono::milliseconds retry_delay,

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -26,6 +26,11 @@ public:
       std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
       std::chrono::milliseconds request_pause =
           std::chrono::milliseconds(1100)) const;
+  Core::IntervalsResult fetch_intervals(
+      int max_retries = 3,
+      std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
+      std::chrono::milliseconds request_pause =
+          std::chrono::milliseconds(1100)) const;
   Core::KlinesResult fetch_klines(
       const std::string &symbol, const std::string &interval, int limit,
       int max_retries = 3,


### PR DESCRIPTION
## Summary
- query interval list from exchangeInfo via DataFetcher
- expose intervals through DataService for app use
- merge, sort, and dedupe intervals before showing in UI

## Testing
- `cmake -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_68a06903f19c83278c28c4282b0d361e