### PR TITLE
Include ImGui internal header for docking features

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -5,6 +5,7 @@
 #include "core/candle.h"
 #include "core/candle_manager.h"
 #include "imgui.h"
+#include "imgui_internal.h"
 #include "implot.h"
 #include "logger.h"
 #include "plot/candlestick.h"


### PR DESCRIPTION
## Summary
- Include `imgui_internal.h` to expose docking API

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake`
- `cmake --build build` *(fails: `expected primary-expression before 'int'` in `src/ui/chart_window.cpp`)*
- `cmake --build build --target test_backtester test_candle_manager test_signal`
- `cd build && ctest --output-on-failure` *(1 failing test: test_signal)*

------
https://chatgpt.com/codex/tasks/task_e_68a098acf4048327856450292f88b8a0