### PR TITLE
Align kline fetching with candle boundaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
+find_package(cpr CONFIG REQUIRED)
 
 if(BUILD_TRADING_TERMINAL)
     # Find all necessary packages using vcpkg
@@ -121,8 +122,27 @@ target_link_libraries(test_signal PRIVATE
 
 add_test(NAME test_signal COMMAND test_signal)
 
+add_executable(test_data_fetcher
+    tests/test_data_fetcher.cpp
+    src/core/data_fetcher.cpp
+    src/candle.cpp
+    src/logger.cpp
+)
+
+target_include_directories(test_data_fetcher PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_data_fetcher PRIVATE
+    GTest::gtest_main
+    cpr::cpr
+    nlohmann_json::nlohmann_json
+)
+
+add_test(NAME test_data_fetcher COMMAND test_data_fetcher)
+
 add_custom_target(ctest
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_backtester test_candle_manager test_signal
+    DEPENDS test_backtester test_candle_manager test_signal test_data_fetcher
 )
 

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -64,15 +64,16 @@ KlinesResult DataFetcher::fetch_klines(
   std::vector<Candle> all_candles;
   long long interval_ms = interval_to_ms(interval);
   auto now = std::chrono::system_clock::now();
-  long long end_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                           now.time_since_epoch())
-                           .count();
+  long long current_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch())
+          .count();
+  long long end_time = current_ms / interval_ms * interval_ms - 1;
   int http_status = 0;
 
   while (static_cast<int>(all_candles.size()) < limit) {
     int batch_limit =
         std::min(1000, limit - static_cast<int>(all_candles.size()));
-    long long start_time = end_time - interval_ms * batch_limit;
+    long long start_time = end_time - interval_ms * batch_limit + 1;
     std::string url = base_url + "&startTime=" + std::to_string(start_time) +
                       "&endTime=" + std::to_string(end_time) + "&limit=" +
                       std::to_string(batch_limit);

--- a/tests/test_data_fetcher.cpp
+++ b/tests/test_data_fetcher.cpp
@@ -1,0 +1,48 @@
+#include "core/data_fetcher.h"
+#include <gtest/gtest.h>
+#include <chrono>
+
+TEST(DataFetcherTest, LatestCandleNoLag) {
+    using namespace Core;
+    long long interval_ms = 60LL * 1000LL; // 1 minute
+    auto res = DataFetcher::fetch_klines(
+        "BTCUSDT", "1m", 1, 3,
+        std::chrono::milliseconds(0),
+        std::chrono::milliseconds(0));
+
+    if (res.error != FetchError::None) {
+        GTEST_SKIP() << "Network error";
+    }
+    ASSERT_EQ(res.candles.size(), 1u);
+
+    auto now = std::chrono::system_clock::now();
+    long long current_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               now.time_since_epoch())
+                               .count();
+    long long expected_open = current_ms / interval_ms * interval_ms - interval_ms;
+    EXPECT_EQ(res.candles[0].open_time, expected_open);
+    EXPECT_EQ(res.candles[0].close_time, expected_open + interval_ms - 1);
+}
+
+TEST(DataFetcherTest, AsyncLatestCandleNoLag) {
+    using namespace Core;
+    long long interval_ms = 60LL * 1000LL; // 1 minute
+    auto fut = DataFetcher::fetch_klines_async(
+        "BTCUSDT", "1m", 1, 3,
+        std::chrono::milliseconds(0),
+        std::chrono::milliseconds(0));
+    auto res = fut.get();
+
+    if (res.error != FetchError::None) {
+        GTEST_SKIP() << "Network error";
+    }
+    ASSERT_EQ(res.candles.size(), 1u);
+
+    auto now = std::chrono::system_clock::now();
+    long long current_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               now.time_since_epoch())
+                               .count();
+    long long expected_open = current_ms / interval_ms * interval_ms - interval_ms;
+    EXPECT_EQ(res.candles[0].open_time, expected_open);
+    EXPECT_EQ(res.candles[0].close_time, expected_open + interval_ms - 1);
+}


### PR DESCRIPTION
## Summary
- align `fetch_klines` time range to candle intervals so the newest closed candle is returned
- test that both synchronous and async fetchers return the latest closed candle when limit=1

## Testing
- `ctest --output-on-failure` *(fails: SignalIndicators.CalculatesMacd)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ae9426b88327858b2b6050a75ab5