### PR TITLE
Add vcpkg manifest for dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "terminal_c",
+  "version": "0.1.0",
+  "dependencies": [
+    { "name": "imgui", "features": [ "docking-experimental", "glfw-binding", "opengl3-binding" ] },
+    "implot",
+    "cpr",
+    "nlohmann-json",
+    "arrow",
+    "glfw3",
+    "opengl"
+  ]
+}


### PR DESCRIPTION
## Summary
- add vcpkg.json manifest listing project dependencies

## Testing
- `bash setup_and_build.bat` *(fails: command not found / Windows batch file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5520cc48327a07d51078ed697fc