### PR TITLE
Support vcpkg manifest installation

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -22,8 +22,14 @@ if exist "%VCPKG_PATH%" (
 
 set TOOLCHAIN_FILE=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake
 
-echo Installing required packages...
-"%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl --recurse
+REM Install dependencies using manifest if available
+if exist "%SCRIPT_DIR%vcpkg.json" (
+    echo Installing packages from manifest...
+    "%VCPKG_PATH%\vcpkg.exe" install --recurse
+) else (
+    echo Installing required packages...
+    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] implot cpr nlohmann-json arrow glfw3 opengl --recurse
+)
 if %errorlevel% neq 0 (
     echo Dependency installation failed!
     pause


### PR DESCRIPTION
## Summary
- Detect vcpkg.json in setup script and install packages via manifest
- Fallback to explicit package list when manifest absent

## Testing
- `cmake ..` *(fails: Could NOT find GTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a485fa808327863e81e8bb38290f