### PR TITLE
Limit symbol list by volume and persist selection

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -501,6 +501,9 @@ int App::run() {
     glfwSwapBuffers(window);
   }
 
+  // Save selected pairs before exiting
+  save_pairs();
+
   // Cleanup
   ImGui_ImplOpenGL3_Shutdown();
   ImGui_ImplGlfw_Shutdown();

--- a/src/core/data_fetcher.h
+++ b/src/core/data_fetcher.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <cstddef>
 
 namespace Core {
 
@@ -73,7 +74,8 @@ public:
                     std::chrono::milliseconds retry_delay =
                         std::chrono::milliseconds(1000),
                     std::chrono::milliseconds request_pause =
-                        std::chrono::milliseconds(1100));
+                        std::chrono::milliseconds(1100),
+                    std::size_t top_n = 100);
 
   static IntervalsResult
   fetch_all_intervals(int max_retries = 3,

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -16,9 +16,9 @@ void DataService::save_selected_pairs(
 
 Core::SymbolsResult DataService::fetch_all_symbols(
     int max_retries, std::chrono::milliseconds retry_delay,
-    std::chrono::milliseconds request_pause) const {
+    std::chrono::milliseconds request_pause, std::size_t top_n) const {
   return Core::DataFetcher::fetch_all_symbols(max_retries, retry_delay,
-                                             request_pause);
+                                             request_pause, top_n);
 }
 
 Core::IntervalsResult DataService::fetch_intervals(

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <cstddef>
 
 #include "core/candle.h"
 #include "core/data_fetcher.h"
@@ -25,7 +26,8 @@ public:
       int max_retries = 3,
       std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),
       std::chrono::milliseconds request_pause =
-          std::chrono::milliseconds(1100)) const;
+          std::chrono::milliseconds(1100),
+      std::size_t top_n = 100) const;
   Core::IntervalsResult fetch_intervals(
       int max_retries = 3,
       std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000),

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <map>
 #include <string>
+#include <cctype>
 
 using namespace Core;
 
@@ -79,8 +80,21 @@ void DrawChartWindow(
     const Core::BacktestResult &last_result) {
   ImGui::Begin("Chart");
 
+  static char pair_filter[64] = "";
+  ImGui::InputText("##pair_filter", pair_filter, IM_ARRAYSIZE(pair_filter));
+  std::string filter_str = pair_filter;
+  std::transform(filter_str.begin(), filter_str.end(), filter_str.begin(),
+                 ::tolower);
+  std::vector<std::string> filtered_pairs;
+  for (const auto &p : pair_list) {
+    std::string lower = p;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    if (filter_str.empty() || lower.find(filter_str) != std::string::npos)
+      filtered_pairs.push_back(p);
+  }
+
   if (ImGui::BeginCombo("Pair", active_pair.c_str())) {
-    for (const auto &p : pair_list) {
+    for (const auto &p : filtered_pairs) {
       bool sel = (p == active_pair);
       if (ImGui::Selectable(p.c_str(), sel))
         active_pair = p;


### PR DESCRIPTION
## Summary
- Limit symbol discovery to top trading pairs by requesting 24h tickers, sorting by quote volume and returning the top N pairs
- Add pair name filter in chart window to quickly narrow dropdown list
- Persist pair list to config on exit so next launch loads the same subset

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: SignalIndicators.CalculatesMacd)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc6aeab48327815e11f8fa4988bd