### PR TITLE
Add row size weights for chart subplots

### DIFF
--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -249,13 +249,15 @@ void DrawChartWindow(
 
   ImPlotFlags plot_flags = ImPlotFlags_Crosshairs;
   ImPlotSubplotFlags subplot_flags = ImPlotSubplotFlags_LinkAllX;
-  int subplot_rows = 2;
+  std::vector<float> row_sizes = {3.f, 1.f};
   if (show_rsi)
-    ++subplot_rows;
+    row_sizes.push_back(2.f);
   if (show_macd)
-    ++subplot_rows;
+    row_sizes.push_back(2.f);
+  int subplot_rows = static_cast<int>(row_sizes.size());
   if (ImPlot::BeginSubplots("##price_volume", subplot_rows, 1,
-                            ImGui::GetContentRegionAvail(), subplot_flags)) {
+                            ImGui::GetContentRegionAvail(), subplot_flags,
+                            row_sizes.data())) {
     if (apply_manual_limits) {
       ImPlot::SetNextAxesLimits(manual_limits.X.Min, manual_limits.X.Max,
                                 manual_limits.Y.Min, manual_limits.Y.Max,


### PR DESCRIPTION
## Summary
- Use `row_sizes` vector to weight subplot rows and keep volume row minimal

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build` *(fails: test_signal)*
- `ctest --test-dir build --rerun-failed --output-on-failure` *(fails: test_signal)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e29e8e948327852da5c7d5feaf78