### PR TITLE
fix: use valid vcpkg manifest name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terminal_c
+# terminal-c
 
 Standalone C++ trading terminal using ImGui and other dependencies. The project relies on packages provided by `vcpkg` and `find_package` in CMake.
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "name": "terminal_c",
+  "name": "terminal-c",
   "version": "0.1.0",
   "dependencies": [
     { "name": "imgui", "features": [ "docking-experimental", "glfw-binding", "opengl3-binding" ] },


### PR DESCRIPTION
## Summary
- rename `terminal_c` manifest to valid package name `terminal-c`
- update README project heading to match

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e61eb3008327b1ff718036ec1549