### PR TITLE
Add GTest dependency and configure CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_definitions(NOMINMAX)
 
 option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
-find_package(GTest REQUIRED)
+find_package(GTest CONFIG REQUIRED)
 find_package(cpr CONFIG QUIET)
 if(NOT cpr_FOUND)
   message(WARNING "cpr not found, skipping targets that require it")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "nlohmann-json",
     "arrow",
     "glfw3",
-    "opengl"
+    "opengl",
+    "gtest"
   ]
 }


### PR DESCRIPTION
## Summary
- include gtest in vcpkg manifest
- use config-based GTest lookup in CMake

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: SignalIndicators.CalculatesMacd)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e901ca248327aba33550c935b96d