### PR TITLE
Remove pair persistence and stream cleanup

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -247,6 +247,19 @@ int App::run() {
   std::string last_active_pair = active_pair;
   std::string last_active_interval = active_interval;
 
+  auto cancel_pair = [&](const std::string &pair) {
+    pending_fetches.erase(pair);
+    fetch_queue.erase(
+        std::remove_if(fetch_queue.begin(), fetch_queue.end(),
+                       [&](const FetchTask &t) { return t.pair == pair; }),
+        fetch_queue.end());
+    auto it = streams.find(pair);
+    if (it != streams.end()) {
+      it->second->stop();
+      streams.erase(it);
+    }
+  };
+
   // Main loop
   while (!glfwWindowShouldClose(window)) {
     glfwPollEvents();
@@ -432,7 +445,7 @@ int App::run() {
 
     DrawControlPanel(pairs, selected_pairs, active_pair, intervals,
                      selected_interval, all_candles, save_pairs, exchange_pairs,
-                     status_);
+                     status_, cancel_pair);
 
     DrawSignalsWindow(strategy, short_period, long_period, oversold, overbought,
                       show_on_chart, signal_entries, buy_times, buy_prices,

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -45,7 +45,8 @@ void DrawControlPanel(
     std::map<std::string, std::map<std::string, std::vector<Candle>>>
         &all_candles,
     const std::function<void()> &save_pairs,
-    const std::vector<std::string> &exchange_pairs, const AppStatus &status) {
+    const std::vector<std::string> &exchange_pairs, const AppStatus &status,
+    const std::function<void(const std::string &)> &cancel_pair) {
   ImGui::Begin("Control Panel");
 
   ImGui::Text("Select pairs to load:");
@@ -224,6 +225,12 @@ void DrawControlPanel(
         active_pair =
             new_active != pairs.end() ? new_active->name : std::string();
       }
+      selected_pairs.erase(std::remove(selected_pairs.begin(),
+                                       selected_pairs.end(), removed),
+                           selected_pairs.end());
+      Config::save_selected_pairs("config.json", selected_pairs);
+      if (cancel_pair)
+        cancel_pair(removed);
       save_pairs();
     } else {
       ++it;

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -22,5 +22,6 @@ void DrawControlPanel(
     std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
     const std::function<void()>& save_pairs,
     const std::vector<std::string>& exchange_pairs,
-    const AppStatus& status);
+    const AppStatus& status,
+    const std::function<void(const std::string&)>& cancel_pair);
 


### PR DESCRIPTION
## Summary
- Remove deleted pairs from selection and persist to config.json
- Add cancellation callback to stop streams and pending fetches when a pair is removed

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- ❌ `ctest --test-dir build --output-on-failure` (SignalIndicators.CalculatesMacd failed)


------
https://chatgpt.com/codex/tasks/task_e_68a0f52840d08327a1472c5cceb5ef8a