### PR TITLE
Handle missing candle intervals

### DIFF
--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -68,6 +68,17 @@ float DistancePointToSegment(const ImVec2 &p, const ImVec2 &v,
 
 } // namespace
 
+void InvalidateCache(const std::string& pair, const std::string& interval) {
+  auto &c = cache[pair][interval];
+  c.times.clear();
+  c.opens.clear();
+  c.highs.clear();
+  c.lows.clear();
+  c.closes.clear();
+  c.volumes.clear();
+  c.last_time = 0;
+}
+
 void DrawChartWindow(
     const std::map<std::string, std::map<std::string, std::vector<Candle>>>
         &all_candles,

--- a/src/ui/chart_window.h
+++ b/src/ui/chart_window.h
@@ -22,3 +22,7 @@ void DrawChartWindow(
     const Journal::Journal& journal,
     const Core::BacktestResult& last_result);
 
+// Reset cached plot data for a specific trading pair and interval so that
+// the next draw rebuilds it from the updated candle list.
+void InvalidateCache(const std::string& pair, const std::string& interval);
+


### PR DESCRIPTION
## Summary
- check for gaps between stored and fetched candles when loading data
- fetch and append missing candles for the gap, then invalidate chart cache
- expose `InvalidateCache` helper in chart window to refresh plotting data

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest` *(fails: SignalIndicators.CalculatesMacd)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f6579e1883279501555722ac8d81