### PR TITLE
Refactor CandleManager into instance-based service

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -168,7 +168,7 @@ void App::load_config() {
                          exchange_interval_res.intervals.end());
   }
   if (pair_names.empty()) {
-    auto stored = CandleManager::list_stored_data();
+    auto stored = data_service_.list_stored_data();
     std::set<std::string> pairs_found;
     std::set<std::string> intervals_found;
     for (const auto &entry : stored) {
@@ -238,7 +238,7 @@ void App::load_config() {
     for (const auto &p : ctx.pairs) {
       std::string pair = p.name;
       auto stream =
-          std::make_unique<KlineStream>(pair, ctx.active_interval);
+          std::make_unique<KlineStream>(pair, ctx.active_interval, data_service_.candle_manager());
       stream->start(
           [pair](const Candle &c) {
             std::lock_guard<std::mutex> lock(ctx.candles_mutex);
@@ -458,7 +458,7 @@ void App::render_ui() {
   DrawControlPanel(ctx.pairs, ctx.selected_pairs, ctx.active_pair,
                    ctx.intervals, ctx.selected_interval, ctx.all_candles,
                    ctx.save_pairs, ctx.exchange_pairs, status_,
-                   ctx.cancel_pair);
+                   data_service_, ctx.cancel_pair);
 
   DrawSignalsWindow(ctx.strategy, ctx.short_period, ctx.long_period,
                     ctx.oversold, ctx.overbought, ctx.show_on_chart,

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -4,30 +4,40 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <mutex>
 
 namespace Core {
 
 class CandleManager {
 public:
+    CandleManager();
+    explicit CandleManager(const std::filesystem::path& dir);
+
     // Saves a vector of candles to a CSV file.
-    static bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
+    bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
 
     // Appends new candles to an existing CSV file, skipping duplicates.
-    static bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
+    bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
 
     // Loads candles from a CSV file into a vector.
-    static std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval);
+    std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval);
 
     // Lists all locally stored candle data files (symbol_interval.csv).
-    static std::vector<std::string> list_stored_data();
+    std::vector<std::string> list_stored_data();
 
     // Allows runtime configuration of the candle data directory
-    static void set_data_dir(const std::filesystem::path& dir);
-    static std::filesystem::path get_data_dir();
+    void set_data_dir(const std::filesystem::path& dir);
+    std::filesystem::path get_data_dir() const;
 
 private:
-    // Helper function to get the full path for a candle CSV file.
-    static std::filesystem::path get_candle_path(const std::string& symbol, const std::string& interval);
+    // Helper functions to get the full path for candle CSV and index files.
+    std::filesystem::path get_candle_path(const std::string& symbol, const std::string& interval) const;
+    std::filesystem::path get_index_path(const std::string& symbol, const std::string& interval) const;
+    long long read_last_open_time(const std::string& symbol, const std::string& interval) const;
+    void write_last_open_time(const std::string& symbol, const std::string& interval, long long open_time) const;
+
+    std::filesystem::path data_dir_;
+    mutable std::mutex mutex_;
 };
 
 } // namespace Core

--- a/src/core/kline_stream.cpp
+++ b/src/core/kline_stream.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <nlohmann/json.hpp>
 
-#include "candle_manager.h"
 #include "logger.h"
 
 #if __has_include(<ixwebsocket/IXWebSocket.h>)
@@ -13,8 +12,9 @@
 
 namespace Core {
 
-KlineStream::KlineStream(const std::string &symbol, const std::string &interval)
-    : symbol_(symbol), interval_(interval) {}
+KlineStream::KlineStream(const std::string &symbol, const std::string &interval,
+                         CandleManager &manager)
+    : symbol_(symbol), interval_(interval), candle_manager_(manager) {}
 
 KlineStream::~KlineStream() { stop(); }
 
@@ -55,7 +55,7 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
                 std::stod(k.value("V", std::string("0"))),
                 std::stod(k.value("Q", std::string("0"))),
                 0.0);
-            CandleManager::append_candles(symbol_, interval_, {c});
+            candle_manager_.append_candles(symbol_, interval_, {c});
             if (cb) cb(c);
           }
         }

--- a/src/core/kline_stream.h
+++ b/src/core/kline_stream.h
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "candle.h"
+#include "candle_manager.h"
 
 namespace Core {
 class KlineStream {
@@ -13,7 +14,8 @@ public:
   using CandleCallback = std::function<void(const Candle&)>;
   using ErrorCallback = std::function<void()>;
 
-  KlineStream(const std::string &symbol, const std::string &interval);
+  KlineStream(const std::string &symbol, const std::string &interval,
+              CandleManager &manager);
   ~KlineStream();
 
   void start(CandleCallback cb, ErrorCallback err_cb = nullptr);
@@ -25,6 +27,7 @@ private:
 
   std::string symbol_;
   std::string interval_;
+  CandleManager &candle_manager_;
   std::thread thread_;
   std::atomic<bool> running_{false};
 };

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -3,6 +3,11 @@
 #include "core/candle_manager.h"
 #include "core/data_fetcher.h"
 
+DataService::DataService() = default;
+
+DataService::DataService(const std::filesystem::path &data_dir)
+    : candle_manager_(data_dir) {}
+
 Core::SymbolsResult DataService::fetch_all_symbols(
     int max_retries, std::chrono::milliseconds retry_delay,
     std::chrono::milliseconds request_pause, std::size_t top_n) const {
@@ -48,18 +53,27 @@ DataService::fetch_klines_async(const std::string &symbol,
 std::vector<Core::Candle>
 DataService::load_candles(const std::string &pair,
                           const std::string &interval) const {
-  return Core::CandleManager::load_candles(pair, interval);
+  return candle_manager_.load_candles(pair, interval);
 }
 
 void DataService::save_candles(
     const std::string &pair, const std::string &interval,
     const std::vector<Core::Candle> &candles) const {
-  Core::CandleManager::save_candles(pair, interval, candles);
+  candle_manager_.save_candles(pair, interval, candles);
 }
 
 void DataService::append_candles(
     const std::string &pair, const std::string &interval,
     const std::vector<Core::Candle> &candles) const {
-  Core::CandleManager::append_candles(pair, interval, candles);
+  candle_manager_.append_candles(pair, interval, candles);
+}
+
+std::vector<std::string> DataService::list_stored_data() const {
+  return candle_manager_.list_stored_data();
+}
+
+Core::CandleManager &DataService::candle_manager() { return candle_manager_; }
+const Core::CandleManager &DataService::candle_manager() const {
+  return candle_manager_;
 }
 

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 
 #include "core/candle.h"
 #include "core/data_fetcher.h"
@@ -16,6 +17,9 @@
 // on high level behaviour.
 class DataService {
 public:
+  DataService();
+  explicit DataService(const std::filesystem::path &data_dir);
+
   // Exchange data ---------------------------------------------------------
   Core::SymbolsResult fetch_all_symbols(
       int max_retries = 3,
@@ -55,5 +59,12 @@ public:
                     const std::vector<Core::Candle> &candles) const;
   void append_candles(const std::string &pair, const std::string &interval,
                       const std::vector<Core::Candle> &candles) const;
+  std::vector<std::string> list_stored_data() const;
+
+  Core::CandleManager &candle_manager() { return candle_manager_; }
+  const Core::CandleManager &candle_manager() const { return candle_manager_; }
+
+private:
+  Core::CandleManager candle_manager_;
 };
 

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -1,7 +1,6 @@
 #include "ui/control_panel.h"
 
 #include "config_manager.h"
-#include "core/candle_manager.h"
 #include "core/data_fetcher.h"
 #include "imgui.h"
 #include "ui/chart_window.h"
@@ -118,6 +117,7 @@ void DrawControlPanel(
         &all_candles,
     const std::function<void()> &save_pairs,
     const std::vector<std::string> &exchange_pairs, const AppStatus &status,
+    DataService &data_service,
     const std::function<void(const std::string &)> &cancel_pair) {
   ImGui::Begin("Control Panel");
 
@@ -168,7 +168,7 @@ void DrawControlPanel(
         }
         bool failed = false;
         for (const auto &interval : intervals) {
-          auto candles = CandleManager::load_candles(symbol, interval);
+          auto candles = data_service.load_candles(symbol, interval);
           long long last_time = candles.empty() ? 0 : candles.back().open_time;
           if (candles.size() < EXPECTED_CANDLES) {
             int missing = EXPECTED_CANDLES - static_cast<int>(candles.size());
@@ -190,7 +190,7 @@ void DrawControlPanel(
                 }
               }
               if (!to_append.empty()) {
-                CandleManager::append_candles(symbol, interval, to_append);
+                data_service.append_candles(symbol, interval, to_append);
                 for (const auto &c : to_append) {
                   if (c.open_time > last_time) {
                     candles.push_back(c);

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -7,6 +7,7 @@
 
 #include "core/candle.h"
 #include "app.h"
+#include "services/data_service.h"
 
 struct PairItem {
     std::string name;
@@ -23,5 +24,6 @@ void DrawControlPanel(
     const std::function<void()>& save_pairs,
     const std::vector<std::string>& exchange_pairs,
     const AppStatus& status,
+    DataService& data_service,
     const std::function<void(const std::string&)>& cancel_pair);
 

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -9,32 +9,32 @@ TEST(CandleManagerTest, SaveLoadAndAppend) {
     std::filesystem::path test_dir = std::filesystem::temp_directory_path() / "candle_manager_test";
     std::filesystem::remove_all(test_dir);
     std::filesystem::create_directories(test_dir);
-    CandleManager::set_data_dir(test_dir);
+    CandleManager cm(test_dir);
 
     std::vector<Candle> candles;
     candles.emplace_back(1,1,1,1,1,1,1,1,1,1,1,0);
-    bool saved = CandleManager::save_candles("TEST","1m",candles);
+    bool saved = cm.save_candles("TEST","1m",candles);
     EXPECT_TRUE(saved);
 
-    auto loaded = CandleManager::load_candles("TEST","1m");
+    auto loaded = cm.load_candles("TEST","1m");
     ASSERT_EQ(loaded.size(), 1);
     EXPECT_EQ(loaded[0].close, 1);
 
-    auto list = CandleManager::list_stored_data();
+    auto list = cm.list_stored_data();
     EXPECT_FALSE(list.empty());
 
     std::vector<Candle> more;
     more.emplace_back(2,2,2,2,2,2,2,2,2,2,2,0);
-    bool appended = CandleManager::append_candles("TEST","1m",more);
+    bool appended = cm.append_candles("TEST","1m",more);
     EXPECT_TRUE(appended);
 
-    loaded = CandleManager::load_candles("TEST","1m");
+    loaded = cm.load_candles("TEST","1m");
     ASSERT_EQ(loaded.size(), 2);
     EXPECT_EQ(loaded[1].open_time, 2);
 
-    bool appended_dup = CandleManager::append_candles("TEST","1m",more);
+    bool appended_dup = cm.append_candles("TEST","1m",more);
     EXPECT_TRUE(appended_dup);
-    loaded = CandleManager::load_candles("TEST","1m");
+    loaded = cm.load_candles("TEST","1m");
     EXPECT_EQ(loaded.size(), 2); // no duplicates
 
     std::filesystem::path idx_path = test_dir / "TEST_1m.idx";
@@ -46,9 +46,9 @@ TEST(CandleManagerTest, SaveLoadAndAppend) {
     idx.close();
 
     std::filesystem::remove(idx_path);
-    bool appended_dup_no_idx = CandleManager::append_candles("TEST","1m",more);
+    bool appended_dup_no_idx = cm.append_candles("TEST","1m",more);
     EXPECT_TRUE(appended_dup_no_idx);
-    loaded = CandleManager::load_candles("TEST","1m");
+    loaded = cm.load_candles("TEST","1m");
     EXPECT_EQ(loaded.size(), 2);
     idx.open(idx_path);
     idx_time = -1;
@@ -58,9 +58,9 @@ TEST(CandleManagerTest, SaveLoadAndAppend) {
 
     std::vector<Candle> next;
     next.emplace_back(3,3,3,3,3,3,3,3,3,3,3,0);
-    bool appended_next = CandleManager::append_candles("TEST","1m",next);
+    bool appended_next = cm.append_candles("TEST","1m",next);
     EXPECT_TRUE(appended_next);
-    loaded = CandleManager::load_candles("TEST","1m");
+    loaded = cm.load_candles("TEST","1m");
     ASSERT_EQ(loaded.size(), 3);
     idx.open(idx_path);
     idx_time = -1;


### PR DESCRIPTION
## Summary
- Convert CandleManager into an instance class storing its own data directory and using a mutex for thread-safe I/O
- Replace direct std::cerr usage with Logger and route DataService and KlineStream through CandleManager instances
- Update UI and tests to use DataService/CandleManager objects instead of static calls

## Testing
- `cmake --build build --target test_candle_manager`
- `cd build && ctest -R test_candle_manager --output-on-failure`
- `cmake --build build` *(fails: templates must have C++ linkage)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cb58207883279bd0533452bbce1d