### PR TITLE
Add reconnecting Kline stream with pluggable WebSocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/data_fetcher.cpp
     src/core/backtester.cpp
     src/core/kline_stream.cpp
+    src/core/iwebsocket.cpp
     src/logger.cpp
     src/journal.cpp
     src/services/data_service.cpp
@@ -129,8 +130,20 @@ target_include_directories(test_scheduler PRIVATE src include)
 target_link_libraries(test_scheduler PRIVATE GTest::gtest_main)
 add_test(NAME test_scheduler COMMAND test_scheduler)
 
+add_executable(test_kline_stream
+  tests/test_kline_stream.cpp
+  src/core/kline_stream.cpp
+  src/core/iwebsocket.cpp
+  src/core/candle_manager.cpp
+  src/candle.cpp
+  src/logger.cpp
+)
+target_include_directories(test_kline_stream PRIVATE src include)
+target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)
+add_test(NAME test_kline_stream COMMAND test_kline_stream)
+
 add_custom_target(ctest COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-  DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_config_manager
+  DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_config_manager test_kline_stream
 )
 if(cpr_FOUND)
   add_dependencies(ctest test_data_fetcher)

--- a/src/core/iwebsocket.cpp
+++ b/src/core/iwebsocket.cpp
@@ -1,0 +1,46 @@
+#include "iwebsocket.h"
+#include "logger.h"
+
+#if __has_include(<ixwebsocket/IXWebSocket.h>)
+#define HAS_IXWEBSOCKET 1
+#include <ixwebsocket/IXWebSocket.h>
+#endif
+
+namespace Core {
+
+#ifdef HAS_IXWEBSOCKET
+class IxWebSocket : public IWebSocket {
+public:
+  void setUrl(const std::string &url) override { ws_.setUrl(url); }
+  void setOnMessage(MessageCallback cb) override { msg_cb_ = std::move(cb); }
+  void setOnError(ErrorCallback cb) override { err_cb_ = std::move(cb); }
+  void start() override {
+    ws_.setOnMessage([this](const ix::WebSocketMessagePtr &msg) {
+      if (msg->type == ix::WebSocketMessageType::Message) {
+        if (msg_cb_) msg_cb_(msg->str);
+      } else if (msg->type == ix::WebSocketMessageType::Error ||
+                 msg->type == ix::WebSocketMessageType::Close) {
+        if (err_cb_) err_cb_();
+      }
+    });
+    ws_.start();
+  }
+  void stop() override { ws_.stop(); }
+
+private:
+  ix::WebSocket ws_;
+  MessageCallback msg_cb_;
+  ErrorCallback err_cb_;
+};
+#endif
+
+WebSocketFactory default_websocket_factory() {
+#ifdef HAS_IXWEBSOCKET
+  return []() { return std::make_unique<IxWebSocket>(); };
+#else
+  return []() { return nullptr; };
+#endif
+}
+
+} // namespace Core
+

--- a/src/core/iwebsocket.h
+++ b/src/core/iwebsocket.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace Core {
+
+class IWebSocket {
+public:
+  using MessageCallback = std::function<void(const std::string&)>;
+  using ErrorCallback = std::function<void()>;
+  virtual ~IWebSocket() = default;
+  virtual void setUrl(const std::string &url) = 0;
+  virtual void setOnMessage(MessageCallback cb) = 0;
+  virtual void setOnError(ErrorCallback cb) = 0;
+  virtual void start() = 0;
+  virtual void stop() = 0;
+};
+
+using WebSocketFactory = std::function<std::unique_ptr<IWebSocket>()>;
+WebSocketFactory default_websocket_factory();
+
+} // namespace Core
+

--- a/src/core/kline_stream.h
+++ b/src/core/kline_stream.h
@@ -4,18 +4,24 @@
 #include <functional>
 #include <string>
 #include <thread>
+#include <chrono>
 
 #include "candle.h"
 #include "candle_manager.h"
+#include "iwebsocket.h"
 
 namespace Core {
 class KlineStream {
 public:
   using CandleCallback = std::function<void(const Candle&)>;
   using ErrorCallback = std::function<void()>;
+  using SleepFunc = std::function<void(std::chrono::milliseconds)>;
 
   KlineStream(const std::string &symbol, const std::string &interval,
-              CandleManager &manager);
+              CandleManager &manager,
+              WebSocketFactory ws_factory = default_websocket_factory(),
+              SleepFunc sleep_func = nullptr,
+              std::chrono::milliseconds base_delay = std::chrono::milliseconds(1000));
   ~KlineStream();
 
   void start(CandleCallback cb, ErrorCallback err_cb = nullptr);
@@ -28,6 +34,9 @@ private:
   std::string symbol_;
   std::string interval_;
   CandleManager &candle_manager_;
+  WebSocketFactory ws_factory_;
+  SleepFunc sleep_func_;
+  std::chrono::milliseconds base_delay_;
   std::thread thread_;
   std::atomic<bool> running_{false};
 };

--- a/tests/test_kline_stream.cpp
+++ b/tests/test_kline_stream.cpp
@@ -1,0 +1,59 @@
+#include "core/kline_stream.h"
+#include "core/candle_manager.h"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <filesystem>
+#include <thread>
+#include <vector>
+#include <chrono>
+
+using namespace Core;
+
+class MockWebSocket : public IWebSocket {
+public:
+  explicit MockWebSocket(int &starts) : starts_(starts) {}
+  void setUrl(const std::string &) override {}
+  void setOnMessage(MessageCallback) override {}
+  void setOnError(ErrorCallback cb) override { err_cb_ = std::move(cb); }
+  void start() override {
+    starts_++;
+    if (err_cb_) {
+      std::thread([cb = err_cb_]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        cb();
+      }).detach();
+    }
+  }
+  void stop() override {}
+
+private:
+  int &starts_;
+  ErrorCallback err_cb_;
+};
+
+TEST(KlineStreamTest, ReconnectsWithBackoff) {
+  std::filesystem::path tmp = std::filesystem::temp_directory_path() / "kline_stream_test";
+  CandleManager mgr(tmp);
+  int starts = 0;
+  auto factory = [&]() { return std::make_unique<MockWebSocket>(starts); };
+  std::vector<int> delays;
+  auto sleep_fn = [&](std::chrono::milliseconds d) {
+    if (d.count() < 50)
+      delays.push_back(static_cast<int>(d.count()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  };
+
+  KlineStream ks("btcusdt", "1m", mgr, factory, sleep_fn, std::chrono::milliseconds(1));
+  std::atomic<int> errors{0};
+  ks.start(nullptr, [&]() { errors++; });
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  ks.stop();
+
+  EXPECT_GE(starts, 2);
+  EXPECT_GE(errors.load(), 1);
+  if (delays.size() >= 2) {
+    EXPECT_EQ(delays[0], 1);
+    EXPECT_EQ(delays[1], 2);
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `IWebSocket` interface and ixwebsocket-backed implementation
- Rework `KlineStream` to reconnect with exponential backoff and allow dependency injection
- Add `test_kline_stream` exercising reconnection logic

## Testing
- `cmake --build build --target test_kline_stream`
- `./build/test_kline_stream`


------
https://chatgpt.com/codex/tasks/task_e_68a1d3c3f7d88327900017caacd166ca