### PR TITLE
Fix DataService CandleManager include and logger warning call

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -155,7 +155,7 @@ void App::load_config() {
     ctx.candles_limit = static_cast<int>(cfg->candles_limit);
     ctx.streaming_enabled = cfg->enable_streaming;
   } else {
-    Logger::instance().warning("Using default configuration");
+    Logger::instance().warn("Using default configuration");
     ctx.candles_limit = 5000;
     ctx.streaming_enabled = false;
   }

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "core/candle.h"
+#include "core/candle_manager.h"
 #include "core/data_fetcher.h"
 #include "core/net/cpr_http_client.h"
 #include "core/net/token_bucket_rate_limiter.h"


### PR DESCRIPTION
## Summary
- include CandleManager header in DataService interface
- replace obsolete Logger::warning call with Logger::warn

## Testing
- `cmake -S . -B build && cmake --build build && cd build && ctest --output-on-failure`
- ⚠️ `test_signal` failed: ConfigTest.LoadSignalConfig


------
https://chatgpt.com/codex/tasks/task_e_68a21a25562083279aa8d2a818a3dffb