### PR TITLE
Add shared interval parsing utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/plot/candlestick.cpp
     src/core/candle_manager.cpp
     src/core/data_fetcher.cpp
+    src/core/interval_utils.cpp
     src/core/net/token_bucket_rate_limiter.cpp
     src/core/net/cpr_http_client.cpp
     src/core/backtester.cpp
@@ -105,6 +106,7 @@ add_test(NAME test_signal COMMAND test_signal)
 add_executable(test_data_fetcher
   tests/test_data_fetcher.cpp
   src/core/data_fetcher.cpp
+  src/core/interval_utils.cpp
   src/candle.cpp
   src/logger.cpp
 )
@@ -112,8 +114,17 @@ target_include_directories(test_data_fetcher PRIVATE src include)
 target_link_libraries(test_data_fetcher PRIVATE GTest::gtest_main)
 add_test(NAME test_data_fetcher COMMAND test_data_fetcher)
 
+add_executable(test_interval_utils
+  tests/test_interval_utils.cpp
+  src/core/interval_utils.cpp
+)
+target_include_directories(test_interval_utils PRIVATE src include)
+target_link_libraries(test_interval_utils PRIVATE GTest::gtest_main)
+add_test(NAME test_interval_utils COMMAND test_interval_utils)
+
 add_executable(test_scheduler
   tests/test_scheduler.cpp
+  src/core/interval_utils.cpp
   src/candle.cpp
 )
 target_include_directories(test_scheduler PRIVATE src include)
@@ -133,6 +144,6 @@ target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)
 add_test(NAME test_kline_stream COMMAND test_kline_stream)
 
 add_custom_target(ctest COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-  DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_kline_stream test_data_fetcher
+  DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_kline_stream test_data_fetcher test_interval_utils
 )
 

--- a/src/core/interval_utils.cpp
+++ b/src/core/interval_utils.cpp
@@ -1,0 +1,34 @@
+#include "interval_utils.h"
+
+namespace Core {
+
+std::chrono::milliseconds parse_interval(const std::string &interval) {
+  if (interval.empty())
+    return std::chrono::milliseconds(0);
+  char unit = interval.back();
+  long long value = 0;
+  try {
+    value = std::stoll(interval.substr(0, interval.size() - 1));
+  } catch (...) {
+    return std::chrono::milliseconds(0);
+  }
+  if (value < 0)
+    return std::chrono::milliseconds(0);
+  switch (unit) {
+  case 's':
+    return std::chrono::milliseconds(value * 1000LL);
+  case 'm':
+    return std::chrono::milliseconds(value * 60LL * 1000LL);
+  case 'h':
+    return std::chrono::milliseconds(value * 60LL * 60LL * 1000LL);
+  case 'd':
+    return std::chrono::milliseconds(value * 24LL * 60LL * 60LL * 1000LL);
+  case 'w':
+    return std::chrono::milliseconds(value * 7LL * 24LL * 60LL * 60LL * 1000LL);
+  default:
+    return std::chrono::milliseconds(0);
+  }
+}
+
+} // namespace Core
+

--- a/src/core/interval_utils.h
+++ b/src/core/interval_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+
+namespace Core {
+
+std::chrono::milliseconds parse_interval(const std::string &interval);
+
+} // namespace Core
+

--- a/tests/test_interval_utils.cpp
+++ b/tests/test_interval_utils.cpp
@@ -1,0 +1,24 @@
+#include "core/interval_utils.h"
+#include <gtest/gtest.h>
+
+using Core::parse_interval;
+
+TEST(IntervalUtilsTest, ParsesValidIntervals) {
+  EXPECT_EQ(parse_interval("1s"), std::chrono::milliseconds(1000));
+  EXPECT_EQ(parse_interval("3m"), std::chrono::milliseconds(3 * 60 * 1000));
+  EXPECT_EQ(parse_interval("2h"),
+            std::chrono::milliseconds(2 * 60 * 60 * 1000LL));
+  EXPECT_EQ(parse_interval("1d"),
+            std::chrono::milliseconds(24 * 60 * 60 * 1000LL));
+  EXPECT_EQ(parse_interval("1w"),
+            std::chrono::milliseconds(7 * 24 * 60 * 60 * 1000LL));
+}
+
+TEST(IntervalUtilsTest, HandlesInvalidIntervals) {
+  EXPECT_EQ(parse_interval(""), std::chrono::milliseconds(0));
+  EXPECT_EQ(parse_interval("10x"), std::chrono::milliseconds(0));
+  EXPECT_EQ(parse_interval("abc"), std::chrono::milliseconds(0));
+  EXPECT_EQ(parse_interval("5"), std::chrono::milliseconds(0));
+  EXPECT_EQ(parse_interval("-5m"), std::chrono::milliseconds(0));
+}
+

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -3,40 +3,13 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
-
-namespace {
-std::chrono::milliseconds interval_to_duration(const std::string &interval) {
-  if (interval.empty())
-    return std::chrono::milliseconds(0);
-  char unit = interval.back();
-  long long value = 0;
-  try {
-    value = std::stoll(interval.substr(0, interval.size() - 1));
-  } catch (...) {
-    return std::chrono::milliseconds(0);
-  }
-  switch (unit) {
-  case 's':
-    return std::chrono::milliseconds(value * 1000LL);
-  case 'm':
-    return std::chrono::milliseconds(value * 60LL * 1000LL);
-  case 'h':
-    return std::chrono::milliseconds(value * 60LL * 60LL * 1000LL);
-  case 'd':
-    return std::chrono::milliseconds(value * 24LL * 60LL * 60LL * 1000LL);
-  case 'w':
-    return std::chrono::milliseconds(value * 7LL * 24LL * 60LL * 60LL * 1000LL);
-  default:
-    return std::chrono::milliseconds(0);
-  }
-}
-} // namespace
+#include "core/interval_utils.h"
 
 TEST(SchedulerTest, AppendsCandleAtBoundary) {
   using namespace Core;
   std::vector<Candle> candles;
   std::string interval = "1m";
-  auto period = interval_to_duration(interval);
+  auto period = parse_interval(interval);
   long long start = 1000;
   candles.emplace_back(start, 0, 0, 0, 0, 0, start + period.count() - 1, 0, 0,
                        0, 0, 0);


### PR DESCRIPTION
## Summary
- add `Core::parse_interval` to convert interval strings to `std::chrono::milliseconds`
- replace ad-hoc interval helpers in app, data fetcher and UI with `parse_interval`
- cover valid and invalid interval formats with new unit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: test_signal, test_kline_stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a22d590928832791ca48af7dfc3b2c