### PR TITLE
Use close callback to block Kline stream and avoid busy wait

### DIFF
--- a/src/core/iwebsocket.h
+++ b/src/core/iwebsocket.h
@@ -10,10 +10,12 @@ class IWebSocket {
 public:
   using MessageCallback = std::function<void(const std::string&)>;
   using ErrorCallback = std::function<void()>;
+  using CloseCallback = std::function<void()>;
   virtual ~IWebSocket() = default;
   virtual void setUrl(const std::string &url) = 0;
   virtual void setOnMessage(MessageCallback cb) = 0;
   virtual void setOnError(ErrorCallback cb) = 0;
+  virtual void setOnClose(CloseCallback cb) = 0;
   virtual void start() = 0;
   virtual void stop() = 0;
 };

--- a/src/core/kline_stream.h
+++ b/src/core/kline_stream.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include <mutex>
+#include <memory>
 
 #include "candle.h"
 #include "candle_manager.h"
@@ -39,6 +41,8 @@ private:
   std::chrono::milliseconds base_delay_;
   std::thread thread_;
   std::atomic<bool> running_{false};
+  std::mutex ws_mutex_;
+  std::unique_ptr<IWebSocket> ws_;
 };
 } // namespace Core
 

--- a/tests/test_kline_stream.cpp
+++ b/tests/test_kline_stream.cpp
@@ -15,20 +15,23 @@ public:
   void setUrl(const std::string &) override {}
   void setOnMessage(MessageCallback) override {}
   void setOnError(ErrorCallback cb) override { err_cb_ = std::move(cb); }
+  void setOnClose(CloseCallback cb) override { close_cb_ = std::move(cb); }
   void start() override {
     starts_++;
-    if (err_cb_) {
-      std::thread([cb = err_cb_]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        cb();
-      }).detach();
-    }
+    std::thread([ec = err_cb_, cc = close_cb_]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      if (ec) ec();
+      if (cc) cc();
+    }).detach();
   }
-  void stop() override {}
+  void stop() override {
+    if (close_cb_) close_cb_();
+  }
 
 private:
   int &starts_;
   ErrorCallback err_cb_;
+  CloseCallback close_cb_;
 };
 
 TEST(KlineStreamTest, ReconnectsWithBackoff) {
@@ -55,5 +58,40 @@ TEST(KlineStreamTest, ReconnectsWithBackoff) {
     EXPECT_EQ(delays[0], 1);
     EXPECT_EQ(delays[1], 2);
   }
+}
+
+class BlockingWebSocket : public IWebSocket {
+public:
+  void setUrl(const std::string &) override {}
+  void setOnMessage(MessageCallback) override {}
+  void setOnError(ErrorCallback) override {}
+  void setOnClose(CloseCallback cb) override { close_cb_ = std::move(cb); }
+  void start() override {}
+  void stop() override {
+    if (close_cb_) close_cb_();
+  }
+
+private:
+  CloseCallback close_cb_;
+};
+
+TEST(KlineStreamTest, StopsPromptly) {
+  std::filesystem::path tmp = std::filesystem::temp_directory_path() / "kline_stream_test2";
+  CandleManager mgr(tmp);
+  auto factory = []() { return std::make_unique<BlockingWebSocket>(); };
+  std::atomic<int> sleeps{0};
+  auto sleep_fn = [&](std::chrono::milliseconds d) {
+    ++sleeps;
+    std::this_thread::sleep_for(d);
+  };
+
+  KlineStream ks("btcusdt", "1m", mgr, factory, sleep_fn, std::chrono::milliseconds(1));
+  ks.start(nullptr, nullptr);
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  auto t0 = std::chrono::steady_clock::now();
+  ks.stop();
+  auto elapsed = std::chrono::steady_clock::now() - t0;
+  EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 20);
+  EXPECT_EQ(sleeps.load(), 0);
 }
 


### PR DESCRIPTION
## Summary
- add close callback support to IWebSocket and default implementation
- refactor KlineStream to wait on a condition variable instead of a sleep loop
- extend tests to exercise prompt stream shutdown and verify backoff

## Testing
- `ctest` *(fails: ConfigTest.LoadSignalConfig, see log)*
- `ctest -R kline_stream`


------
https://chatgpt.com/codex/tasks/task_e_68a230bf1b148327b10ca7887cbb17f8