### PR TITLE
Ensure const correctness in data service and candle manager

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -219,7 +219,7 @@ void App::load_config() {
       auto stream =
           std::make_unique<KlineStream>(pair, this->ctx_->active_interval, data_service_.candle_manager());
       stream->start(
-          [pair](const Candle &c) {
+          [this, pair](const Candle &c) {
             std::lock_guard<std::mutex> lock(this->ctx_->candles_mutex);
             auto &vec = this->ctx_->all_candles[pair][this->ctx_->active_interval];
             if (vec.empty() || c.open_time > vec.back().open_time)

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -183,7 +183,7 @@ void CandleManager::write_last_open_time(const std::string& symbol, const std::s
     }
 }
 
-bool CandleManager::save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) {
+bool CandleManager::save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::filesystem::path path_to_save = get_candle_path(symbol, interval);
     std::ofstream file(path_to_save);
@@ -222,7 +222,7 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
     return true;
 }
 
-bool CandleManager::append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) {
+bool CandleManager::append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::filesystem::path path_to_save = get_candle_path(symbol, interval);
     long long last_open_time = read_last_open_time(symbol, interval);
@@ -261,7 +261,7 @@ bool CandleManager::append_candles(const std::string& symbol, const std::string&
     return true;
 }
 
-std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const std::string& interval) {
+std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const std::string& interval) const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::filesystem::path path = get_candle_path(symbol, interval);
     std::vector<Candle> candles;
@@ -336,7 +336,7 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
     return candles;
 }
 
-std::vector<std::string> CandleManager::list_stored_data() {
+std::vector<std::string> CandleManager::list_stored_data() const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::vector<std::string> stored_files;
     if (std::filesystem::exists(data_dir_) && std::filesystem::is_directory(data_dir_)) {

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -14,16 +14,16 @@ public:
     explicit CandleManager(const std::filesystem::path& dir);
 
     // Saves a vector of candles to a CSV file.
-    bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
+    bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const;
 
     // Appends new candles to an existing CSV file, skipping duplicates.
-    bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles);
+    bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const;
 
     // Loads candles from a CSV file into a vector.
-    std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval);
+    std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval) const;
 
     // Lists all locally stored candle data files (symbol_interval.csv).
-    std::vector<std::string> list_stored_data();
+    std::vector<std::string> list_stored_data() const;
 
     // Allows runtime configuration of the candle data directory
     void set_data_dir(const std::filesystem::path& dir);

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -68,8 +68,3 @@ std::vector<std::string> DataService::list_stored_data() const {
   return candle_manager_.list_stored_data();
 }
 
-Core::CandleManager &DataService::candle_manager() { return candle_manager_; }
-const Core::CandleManager &DataService::candle_manager() const {
-  return candle_manager_;
-}
-


### PR DESCRIPTION
## Summary
- Remove duplicate candle manager accessors from data service and enforce const usage for storage helpers
- Mark candle manager file operations as const for safe use from const services
- Capture `this` in kline stream callbacks to allow access to context

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: test_kline_stream subprocess aborted: std::system_error Invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68a23fa377b48327ac23eb64f43a8e35