### PR TITLE
Add service-based candle range fetching with gap filling

### DIFF
--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -41,6 +41,11 @@ public:
       const std::string &symbol, const std::string &interval, int limit,
       int max_retries = 3,
       std::chrono::milliseconds retry_delay = std::chrono::milliseconds(1000)) const;
+  Core::KlinesResult fetch_range(
+      const std::string &symbol, const std::string &interval,
+      long long start_time, long long end_time, int max_retries = 3,
+      std::chrono::milliseconds retry_delay =
+          std::chrono::milliseconds(1000)) const;
   std::future<Core::KlinesResult> fetch_klines_async(
       const std::string &symbol, const std::string &interval, int limit,
       int max_retries = 3,


### PR DESCRIPTION
## Summary
- add DataService::fetch_range to request Binance ranges or Gate.io for 5s/15s and fill missing candles
- remove UI-level HTTP logic and use service-level range fetching
- clear load error when missing candles are loaded successfully

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a251d3ab40832794790d88401a624a