### PR TITLE
Fill gaps in loaded candles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_test(NAME test_backtester COMMAND test_backtester)
 add_executable(test_candle_manager
   tests/test_candle_manager.cpp
   src/core/candle_manager.cpp
+  src/core/interval_utils.cpp
   src/candle.cpp
   src/logger.cpp
 )
@@ -138,6 +139,7 @@ add_executable(test_kline_stream
   src/core/kline_stream.cpp
   src/core/iwebsocket.cpp
   src/core/candle_manager.cpp
+  src/core/interval_utils.cpp
   src/candle.cpp
   src/logger.cpp
 )

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <nlohmann/json.hpp>
 #include "logger.h"
+#include "interval_utils.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -101,6 +102,25 @@ std::filesystem::path resolve_data_dir() {
 
     std::filesystem::create_directories(dir);
     return dir;
+}
+
+void fill_missing(std::vector<Candle> &candles, long long interval_ms) {
+    if (candles.size() < 2 || interval_ms <= 0) return;
+    std::vector<Candle> filled;
+    filled.reserve(candles.size());
+    for (std::size_t i = 0; i + 1 < candles.size(); ++i) {
+        const auto &cur = candles[i];
+        const auto &next = candles[i + 1];
+        filled.push_back(cur);
+        long long expected = cur.open_time + interval_ms;
+        while (expected < next.open_time) {
+            filled.emplace_back(expected, cur.close, cur.close, cur.close, cur.close,
+                               0.0, expected + interval_ms - 1, 0.0, 0, 0.0, 0.0, 0.0);
+            expected += interval_ms;
+        }
+    }
+    filled.push_back(candles.back());
+    candles = std::move(filled);
 }
 
 } // unnamed namespace
@@ -333,6 +353,14 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
     }
 
     file.close();
+
+    auto interval_ms = parse_interval(interval).count();
+    if (interval_ms > 0) {
+        fill_missing(candles, interval_ms);
+    } else {
+        Logger::instance().warn("Could not determine interval '" + interval + "' for " + symbol);
+    }
+
     return candles;
 }
 


### PR DESCRIPTION
## Summary
- fill gaps between stored candles by calling `fill_missing` with `parse_interval`
- warn when interval cannot be determined
- link interval utilities in test builds

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a258d8b14c8327a38e5bafb7990747