### PR TITLE
Consolidate trade events into single structure

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -3,7 +3,19 @@
 #include "services/data_service.h"
 #include "services/journal_service.h"
 #include "ui/ui_manager.h"
+#include "ui/control_panel.h"
+#include "ui/signal_entry.h"
+#include "core/candle.h"
+#include "core/kline_stream.h"
+#include "core/backtester.h"
+#include "config_manager.h"
 
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <future>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -35,7 +47,58 @@ private:
   void render_ui();
   void cleanup();
 
-  struct AppContext;
+  struct AppContext {
+    struct TradeEvent {
+      double time;
+      double price;
+      enum class Side { Buy, Sell } side;
+    };
+    std::vector<PairItem> pairs;
+    std::vector<std::string> selected_pairs;
+    std::string active_pair;
+    std::string active_interval;
+    std::vector<std::string> intervals;
+    std::vector<std::string> exchange_pairs;
+    std::string selected_interval;
+    std::string strategy = "sma_crossover";
+    int short_period = 9;
+    int long_period = 21;
+    double oversold = 30.0;
+    double overbought = 70.0;
+    bool show_on_chart = false;
+    std::vector<SignalEntry> signal_entries;
+    std::vector<TradeEvent> trades;
+    std::map<std::string, std::map<std::string, std::vector<Core::Candle>>> all_candles;
+    std::mutex candles_mutex;
+    std::map<std::string, std::unique_ptr<Core::KlineStream>> streams;
+    std::atomic<bool> stream_failed{false};
+    struct PendingFetch {
+      std::string interval;
+      std::future<Core::KlinesResult> future;
+    };
+    std::map<std::string, PendingFetch> pending_fetches;
+    Core::BacktestResult last_result;
+    Config::SignalConfig last_signal_cfg;
+    struct FetchTask {
+      std::string pair;
+      std::string interval;
+      std::future<Core::KlinesResult> future;
+      std::chrono::steady_clock::time_point start;
+    };
+    std::deque<FetchTask> fetch_queue;
+    std::size_t total_fetches = 0;
+    std::size_t completed_fetches = 0;
+    std::atomic<long long> next_fetch_time{0};
+    int candles_limit = 0;
+    bool streaming_enabled = false;
+    std::function<void()> save_pairs;
+    std::function<void(const std::string &)> cancel_pair;
+    std::string last_active_pair;
+    std::string last_active_interval;
+    const std::chrono::seconds fetch_backoff{5};
+    const std::chrono::seconds request_timeout{10};
+  };
+
   std::unique_ptr<AppContext> ctx_;
   DataService data_service_;
   JournalService journal_service_;

--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -86,9 +86,8 @@ void DrawChartWindow(
     std::string &active_pair, std::string &active_interval,
     const std::vector<std::string> &pair_list,
     const std::vector<std::string> &interval_list, bool show_on_chart,
-    const std::vector<double> &buy_times, const std::vector<double> &buy_prices,
-    const std::vector<double> &sell_times,
-    const std::vector<double> &sell_prices, const Journal::Journal &journal,
+    const std::vector<App::AppContext::TradeEvent> &trades,
+    const Journal::Journal &journal,
     const Core::BacktestResult &last_result) {
   ImGui::Begin("Chart");
 
@@ -507,14 +506,29 @@ void DrawChartWindow(
     double py[2] = {price, price};
     ImPlot::SetNextLineStyle(ImVec4(0, 1, 0, 1));
     ImPlot::PlotLine("##price", px, py, 2);
-    if (show_on_chart) {
+    if (show_on_chart && !trades.empty()) {
+      std::vector<double> buy_times, buy_prices, sell_times, sell_prices;
+      buy_times.reserve(trades.size());
+      buy_prices.reserve(trades.size());
+      sell_times.reserve(trades.size());
+      sell_prices.reserve(trades.size());
+      for (const auto &tr : trades) {
+        if (tr.side == App::AppContext::TradeEvent::Side::Buy) {
+          buy_times.push_back(tr.time);
+          buy_prices.push_back(tr.price);
+        } else {
+          sell_times.push_back(tr.time);
+          sell_prices.push_back(tr.price);
+        }
+      }
       if (!buy_times.empty()) {
         ImPlot::SetNextMarkerStyle(ImPlotMarker_Up, 6, ImVec4(0, 1, 0, 1));
         ImPlot::PlotScatter("Buy", buy_times.data(), buy_prices.data(),
                             (int)buy_times.size());
       }
       if (!sell_times.empty()) {
-        ImPlot::SetNextMarkerStyle(ImPlotMarker_Down, 6, ImVec4(1, 0, 0, 1));
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Down, 6,
+                                   ImVec4(1, 0, 0, 1));
         ImPlot::PlotScatter("Sell", sell_times.data(), sell_prices.data(),
                             (int)sell_times.size());
       }

--- a/src/ui/chart_window.h
+++ b/src/ui/chart_window.h
@@ -7,6 +7,7 @@
 #include "core/candle.h"
 #include "journal.h"
 #include "core/backtester.h"
+#include "app.h"
 
 void DrawChartWindow(
     const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
@@ -15,10 +16,7 @@ void DrawChartWindow(
     const std::vector<std::string>& pair_list,
     const std::vector<std::string>& interval_list,
     bool show_on_chart,
-    const std::vector<double>& buy_times,
-    const std::vector<double>& buy_prices,
-    const std::vector<double>& sell_times,
-    const std::vector<double>& sell_prices,
+    const std::vector<App::AppContext::TradeEvent>& trades,
     const Journal::Journal& journal,
     const Core::BacktestResult& last_result);
 

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -6,8 +6,9 @@
 #include <functional>
 
 #include "core/candle.h"
-#include "app.h"
 #include "services/data_service.h"
+
+struct AppStatus;
 
 struct PairItem {
     std::string name;

--- a/src/ui/signal_entry.h
+++ b/src/ui/signal_entry.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct SignalEntry {
+    double time;
+    double price;
+    double value1;
+    double value2;
+    int type;
+};
+

--- a/src/ui/signals_window.h
+++ b/src/ui/signals_window.h
@@ -6,14 +6,7 @@
 
 #include "core/candle.h"
 #include "app.h"
-
-struct SignalEntry {
-    double time;
-    double price;
-    double value1;
-    double value2;
-    int type;
-};
+#include "ui/signal_entry.h"
 
 void DrawSignalsWindow(
     std::string& strategy,
@@ -23,10 +16,7 @@ void DrawSignalsWindow(
     double& overbought,
     bool& show_on_chart,
     std::vector<SignalEntry>& signal_entries,
-    std::vector<double>& buy_times,
-    std::vector<double>& buy_prices,
-    std::vector<double>& sell_times,
-    std::vector<double>& sell_prices,
+    std::vector<App::AppContext::TradeEvent>& trades,
     const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
     const std::string& active_pair,
     const std::string& selected_interval,


### PR DESCRIPTION
## Summary
- add TradeEvent to AppContext and track trades in a single vector
- update signal generation to populate trades and chart window to plot them
- expose SignalEntry as a dedicated header and clean up control panel dependencies

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a25ba30f58832790389273fa904662