### PR TITLE
Replace status log vector with deque

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -45,7 +45,7 @@ void App::add_status(const std::string &msg) {
   std::lock_guard<std::mutex> lock(status_mutex_);
   status_.log.push_back(msg);
   if (status_.log.size() > 50)
-    status_.log.erase(status_.log.begin());
+    status_.log.pop_front();
 }
 
 bool App::init_window() {

--- a/src/app.h
+++ b/src/app.h
@@ -26,7 +26,7 @@ struct AppStatus {
   std::string analysis_message = "Idle";
   std::string signal_message = "Idle";
   std::string error_message;
-  std::vector<std::string> log;
+  std::deque<std::string> log;
 };
 
 // The App class owns the services and drives the main event loop.

--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -76,7 +76,7 @@ void DrawSignalsWindow(
     if (need_recalc) {
         status.signal_message = "Computing signals";
         status.log.push_back("Computing signals for " + active_pair + " " + selected_interval);
-        if (status.log.size() > 50) status.log.erase(status.log.begin());
+        if (status.log.size() > 50) status.log.pop_front();
         cache.strategy = strategy;
         cache.short_period = short_period;
         cache.long_period = long_period;


### PR DESCRIPTION
## Summary
- use `std::deque` for `AppStatus::log` to support efficient removal of oldest entries
- drop oldest log messages with `pop_front` in `App::add_status`
- adjust signals window to respect `deque`-based log buffering

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a25f36d8288327adbffe0846728474