### PR TITLE
refactor: centralize retry scheduling

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -46,6 +46,7 @@ private:
   void process_events();
   void render_ui();
   void cleanup();
+  void update_next_fetch_time(long long candidate);
 
   struct AppContext {
     struct TradeEvent {


### PR DESCRIPTION
## Summary
- add `update_next_fetch_time` helper to centralize next fetch scheduling
- use the helper in `process_events` and log errors consistently

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a260b704c48327a009c279a902bf49