### PR TITLE
Centralize retry scheduling in App

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -47,6 +47,7 @@ private:
   void render_ui();
   void cleanup();
   void update_next_fetch_time(long long candidate);
+  void schedule_retry(long long now_ms, const std::string &msg = "");
 
   struct AppContext {
     struct TradeEvent {


### PR DESCRIPTION
## Summary
- add private `schedule_retry` to compute retry delay and log errors
- refactor `process_events` to reuse retry helper for stale or failed updates

## Testing
- `./build/test_backtester`
- `ctest --test-dir build` *(fails: Unable to find executable: /workspace/terminal_c/build/test_signal)*

------
https://chatgpt.com/codex/tasks/task_e_68a2625aeb4c83279a242b2f12373de0