### PR TITLE
Refactor logger into Core namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/backtester.cpp
     src/core/kline_stream.cpp
     src/core/iwebsocket.cpp
-    src/logger.cpp
+    src/core/logger.cpp
     src/journal.cpp
     src/services/data_service.cpp
     src/services/journal_service.cpp
@@ -87,7 +87,7 @@ add_executable(test_candle_manager
   src/core/candle_manager.cpp
   src/core/interval_utils.cpp
   src/candle.cpp
-  src/logger.cpp
+  src/core/logger.cpp
 )
 target_include_directories(test_candle_manager PRIVATE src include)
 target_link_libraries(test_candle_manager PRIVATE GTest::gtest_main)
@@ -100,7 +100,7 @@ add_executable(test_signal
   src/services/signal_bot.cpp
   src/config_manager.cpp
   src/config_schema.cpp
-  src/logger.cpp
+  src/core/logger.cpp
 )
 target_include_directories(test_signal PRIVATE src include)
 target_link_libraries(test_signal PRIVATE GTest::gtest_main)
@@ -111,7 +111,7 @@ add_executable(test_data_fetcher
   src/core/data_fetcher.cpp
   src/core/interval_utils.cpp
   src/candle.cpp
-  src/logger.cpp
+  src/core/logger.cpp
 )
 target_include_directories(test_data_fetcher PRIVATE src include)
 target_link_libraries(test_data_fetcher PRIVATE GTest::gtest_main)
@@ -141,7 +141,7 @@ add_executable(test_kline_stream
   src/core/candle_manager.cpp
   src/core/interval_utils.cpp
   src/candle.cpp
-  src/logger.cpp
+  src/core/logger.cpp
 )
 target_include_directories(test_kline_stream PRIVATE src include)
 target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)
@@ -149,7 +149,7 @@ add_test(NAME test_kline_stream COMMAND test_kline_stream)
 
 add_executable(test_logger
   tests/test_logger.cpp
-  src/logger.cpp
+  src/core/logger.cpp
 )
 target_include_directories(test_logger PRIVATE src include)
 target_link_libraries(test_logger PRIVATE GTest::gtest_main)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -9,7 +9,7 @@
 #include "imgui.h"
 #include "imgui_internal.h"
 #include "implot.h"
-#include "logger.h"
+#include "core/logger.h"
 #include "plot/candlestick.h"
 #include "signal.h"
 
@@ -50,25 +50,25 @@ void App::add_status(const std::string &msg) {
 
 bool App::init_window() {
   auto cfg = Config::ConfigManager::load("config.json");
-  auto level = cfg ? cfg->log_level : LogLevel::Info;
-  Logger::instance().set_min_level(level);
+  auto level = cfg ? cfg->log_level : Core::LogLevel::Info;
+  Core::Logger::instance().set_min_level(level);
   bool console = cfg ? cfg->log_to_console : true;
   bool file = cfg ? cfg->log_to_file : true;
-  Logger::instance().enable_console_output(console);
+  Core::Logger::instance().enable_console_output(console);
   if (file)
-    Logger::instance().set_file(cfg ? cfg->log_file : "terminal.log");
+    Core::Logger::instance().set_file(cfg ? cfg->log_file : "terminal.log");
   else
-    Logger::instance().set_file("");
-  Logger::instance().info("Application started");
+    Core::Logger::instance().set_file("");
+  Core::Logger::instance().info("Application started");
   status_ = AppStatus{};
 
   if (!glfwInit()) {
-    Logger::instance().error("Failed to initialize GLFW");
+    Core::Logger::instance().error("Failed to initialize GLFW");
     return false;
   }
   window_ = glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
   if (!window_) {
-    Logger::instance().error("Failed to create GLFW window");
+    Core::Logger::instance().error("Failed to create GLFW window");
     glfwTerminate();
     return false;
   }
@@ -87,7 +87,7 @@ void App::load_config() {
     this->ctx_->candles_limit = static_cast<int>(cfg->candles_limit);
     this->ctx_->streaming_enabled = cfg->enable_streaming;
   } else {
-    Logger::instance().warn("Using default configuration");
+    Core::Logger::instance().warn("Using default configuration");
     this->ctx_->candles_limit = 5000;
     this->ctx_->streaming_enabled = false;
   }
@@ -301,7 +301,7 @@ void App::process_events() {
       } else {
         status_.error_message = "Failed to fetch " + it->pair + " " +
                                 it->interval + ", retrying";
-        Logger::instance().error(status_.error_message);
+        Core::Logger::instance().error(status_.error_message);
         add_status(status_.error_message);
         int miss = this->ctx_->candles_limit -
                    static_cast<int>(this->ctx_->all_candles[it->pair][it->interval].size());
@@ -316,7 +316,7 @@ void App::process_events() {
       if (std::chrono::steady_clock::now() - it->start > this->ctx_->request_timeout) {
         status_.error_message = "Timeout fetching " + it->pair + " " +
                                 it->interval + ", retrying";
-        Logger::instance().error(status_.error_message);
+        Core::Logger::instance().error(status_.error_message);
         add_status(status_.error_message);
         int miss = this->ctx_->candles_limit -
                    static_cast<int>(this->ctx_->all_candles[it->pair][it->interval].size());
@@ -338,7 +338,7 @@ void App::process_events() {
 void App::schedule_retry(long long now_ms, const std::string &msg) {
   if (!msg.empty()) {
     status_.error_message = msg;
-    Logger::instance().error(status_.error_message);
+    Core::Logger::instance().error(status_.error_message);
     add_status(status_.error_message);
   }
   long long retry =
@@ -512,7 +512,7 @@ void App::cleanup() {
     window_ = nullptr;
   }
   glfwTerminate();
-  Logger::instance().info("Application exiting");
+  Core::Logger::instance().info("Application exiting");
 }
 
 int App::run() {

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -10,7 +10,7 @@ namespace Config {
 std::optional<ConfigData> ConfigManager::load(const std::string &filename) {
     std::ifstream in(filename);
     if (!in.is_open()) {
-        Logger::instance().error("Failed to open " + filename);
+        Core::Logger::instance().error("Failed to open " + filename);
         return std::nullopt;
     }
     try {
@@ -20,12 +20,12 @@ std::optional<ConfigData> ConfigManager::load(const std::string &filename) {
         std::string error;
         auto cfg = ConfigSchema::parse(j, error);
         if (!cfg) {
-            Logger::instance().error(error + " in " + filename);
+            Core::Logger::instance().error(error + " in " + filename);
             return std::nullopt;
         }
         return cfg;
     } catch (const std::exception &e) {
-        Logger::instance().error(std::string("Failed to parse ") + filename + ": " + e.what());
+        Core::Logger::instance().error(std::string("Failed to parse ") + filename + ": " + e.what());
         return std::nullopt;
     }
 }
@@ -39,14 +39,14 @@ bool ConfigManager::save_selected_pairs(const std::string &filename,
             try {
                 in >> j;
             } catch (const std::exception &e) {
-                Logger::instance().warn(std::string("Failed to parse existing ") + filename + ": " + e.what());
+                Core::Logger::instance().warn(std::string("Failed to parse existing ") + filename + ": " + e.what());
             }
         }
     }
     j["pairs"] = pairs;
     std::ofstream out(filename);
     if (!out.is_open()) {
-        Logger::instance().error("Failed to open " + filename + " for writing");
+        Core::Logger::instance().error("Failed to open " + filename + " for writing");
         return false;
     }
     out << j.dump(4);

--- a/src/config_manager.h
+++ b/src/config_manager.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "logger.h"
+#include "core/logger.h"
 
 namespace Config {
 
@@ -18,7 +18,7 @@ struct SignalConfig {
 
 struct ConfigData {
     std::vector<std::string> pairs{};
-    LogLevel log_level{LogLevel::Info};
+    Core::LogLevel log_level{Core::LogLevel::Info};
     bool log_to_file{true};
     bool log_to_console{true};
     std::string log_file{"terminal.log"};

--- a/src/config_schema.cpp
+++ b/src/config_schema.cpp
@@ -27,11 +27,11 @@ std::optional<ConfigData> ConfigSchema::parse(const nlohmann::json &j,
         }
         std::string level = j["log_level"].get<std::string>();
         if (level == "INFO")
-            cfg.log_level = LogLevel::Info;
+            cfg.log_level = Core::LogLevel::Info;
         else if (level == "WARN" || level == "WARNING")
-            cfg.log_level = LogLevel::Warning;
+            cfg.log_level = Core::LogLevel::Warning;
         else if (level == "ERROR")
-            cfg.log_level = LogLevel::Error;
+            cfg.log_level = Core::LogLevel::Error;
         else {
             error = "Unknown log level '" + level + "'";
             return std::nullopt;

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -7,7 +7,7 @@
 #include <string_view>
 #include <array>
 #include <nlohmann/json.hpp>
-#include "logger.h"
+#include "core/logger.h"
 #include "interval_utils.h"
 
 #ifdef _WIN32

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -1,6 +1,6 @@
 #include "data_fetcher.h"
 
-#include "logger.h"
+#include "core/logger.h"
 #include "interval_utils.h"
 #include <algorithm>
 #include <chrono>

--- a/src/core/iwebsocket.cpp
+++ b/src/core/iwebsocket.cpp
@@ -1,5 +1,5 @@
 #include "iwebsocket.h"
-#include "logger.h"
+#include "core/logger.h"
 
 #if __has_include(<ixwebsocket/IXWebSocket.h>)
 #define HAS_IXWEBSOCKET 1

--- a/src/core/kline_stream.cpp
+++ b/src/core/kline_stream.cpp
@@ -6,7 +6,7 @@
 #include <nlohmann/json.hpp>
 #include <thread>
 
-#include "logger.h"
+#include "core/logger.h"
 
 namespace Core {
 

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -1,4 +1,4 @@
-#include "logger.h"
+#include "core/logger.h"
 
 #include <chrono>
 #include <ctime>
@@ -6,6 +6,8 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+
+namespace Core {
 
 Logger &Logger::instance() {
   static Logger inst;
@@ -137,3 +139,4 @@ void Logger::process_queue() {
   }
 }
 
+} // namespace Core

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -8,6 +8,8 @@
 #include <thread>
 #include <chrono>
 
+namespace Core {
+
 enum class LogLevel { Info, Warning, Error };
 
 class Logger {
@@ -45,4 +47,6 @@ private:
   std::size_t max_file_size_ = 1024 * 1024;
   std::string level_to_string(LogLevel level);
 };
+
+} // namespace Core
 

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -1,5 +1,5 @@
 #include "journal.h"
-#include "logger.h"
+#include "core/logger.h"
 #include <array>
 #include <charconv>
 #include <fstream>
@@ -12,7 +12,7 @@ namespace Journal {
 bool Journal::load_json(const std::string &filename) {
   std::ifstream f(filename);
   if (!f.is_open()) {
-    Logger::instance().error("Failed to open journal file: " + filename);
+    Core::Logger::instance().error("Failed to open journal file: " + filename);
     return false;
   }
 
@@ -20,12 +20,12 @@ bool Journal::load_json(const std::string &filename) {
   buffer << f.rdbuf();
   std::string content = buffer.str();
   if (content.empty()) {
-    Logger::instance().error("Journal file is empty: " + filename);
+    Core::Logger::instance().error("Journal file is empty: " + filename);
     return false;
   }
   if (!nlohmann::json::accept(content)) {
-    Logger::instance().error("Invalid JSON format in journal file: " +
-                             filename);
+    Core::Logger::instance().error("Invalid JSON format in journal file: " +
+                                   filename);
     return false;
   }
 
@@ -33,12 +33,13 @@ bool Journal::load_json(const std::string &filename) {
   try {
     j = nlohmann::json::parse(content);
   } catch (const std::exception &e) {
-    Logger::instance().error("Journal parse error: " + std::string(e.what()));
+    Core::Logger::instance().error("Journal parse error: " +
+                                   std::string(e.what()));
     return false;
   }
 
   if (!j.is_array()) {
-    Logger::instance().error("Journal JSON is not an array.");
+    Core::Logger::instance().error("Journal JSON is not an array.");
     return false;
   }
 
@@ -94,7 +95,7 @@ bool Journal::load_csv(const std::string &filename) {
       start = comma + 1;
     }
     if (idx != fields.size()) {
-      Logger::instance().error("Malformed journal line: " + line);
+      Core::Logger::instance().error("Malformed journal line: " + line);
       continue;
     }
 
@@ -114,7 +115,7 @@ bool Journal::load_csv(const std::string &filename) {
     if (!parse_double(fields[2], e.price) ||
         !parse_double(fields[3], e.quantity) ||
         !parse_ll(fields[4], e.timestamp)) {
-      Logger::instance().error("Failed to parse journal line: " + line);
+      Core::Logger::instance().error("Failed to parse journal line: " + line);
       continue;
     }
 

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1,4 +1,4 @@
-#include "logger.h"
+#include "core/logger.h"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <filesystem>
@@ -7,11 +7,11 @@
 
 TEST(LoggerAsync, NonBlockingLogging) {
     auto tmp = std::filesystem::temp_directory_path() / "async_log_test.log";
-    Logger::instance().set_file(tmp.string());
-    Logger::instance().enable_console_output(false);
+    Core::Logger::instance().set_file(tmp.string());
+    Core::Logger::instance().enable_console_output(false);
     auto start = std::chrono::steady_clock::now();
     for (int i = 0; i < 1000; ++i) {
-        Logger::instance().info("message" + std::to_string(i));
+        Core::Logger::instance().info("message" + std::to_string(i));
     }
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
@@ -24,6 +24,6 @@ TEST(LoggerAsync, NonBlockingLogging) {
         ++count;
     EXPECT_EQ(count, 1000);
     in.close();
-    Logger::instance().set_file("");
+    Core::Logger::instance().set_file("");
     std::filesystem::remove(tmp);
 }

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -52,7 +52,7 @@ TEST(ConfigTest, LoadSignalConfig) {
     auto cfg = Config::ConfigManager::load(tmp.string());
     ASSERT_TRUE(cfg.has_value());
     EXPECT_TRUE(cfg->pairs.empty());
-    EXPECT_EQ(cfg->log_level, LogLevel::Info);
+    EXPECT_EQ(cfg->log_level, Core::LogLevel::Info);
     EXPECT_EQ(cfg->candles_limit, 5000u);
     EXPECT_FALSE(cfg->enable_streaming);
     EXPECT_EQ(cfg->signal.type, "sma_crossover");


### PR DESCRIPTION
## Summary
- Move logging implementation into `src/core` and wrap it in the `Core` namespace
- Update includes and usages to reference `core/logger.h` and `Core::Logger`
- Adjust CMake targets to use the new logger location

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a2ce1621b48327a61d44bb58cd0e28