### PR TITLE
Remove local candles when pair deleted

### DIFF
--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -22,6 +22,9 @@ public:
     // Loads candles from a CSV file into a vector.
     std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval) const;
 
+    // Removes all files with the given symbol prefix (symbol_*).
+    bool remove_candles(const std::string& symbol) const;
+
     // Lists all locally stored candle data files (symbol_interval.csv).
     std::vector<std::string> list_stored_data() const;
 

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -258,6 +258,10 @@ void DataService::append_candles(
   candle_manager_.append_candles(pair, interval, candles);
 }
 
+bool DataService::remove_candles(const std::string &pair) const {
+  return candle_manager_.remove_candles(pair);
+}
+
 std::vector<std::string> DataService::list_stored_data() const {
   return candle_manager_.list_stored_data();
 }

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -58,6 +58,7 @@ public:
                     const std::vector<Core::Candle> &candles) const;
   void append_candles(const std::string &pair, const std::string &interval,
                       const std::vector<Core::Candle> &candles) const;
+  bool remove_candles(const std::string &pair) const;
   std::vector<std::string> list_stored_data() const;
 
   Core::CandleManager &candle_manager() { return candle_manager_; }

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -264,6 +264,7 @@ void DrawControlPanel(
           std::remove(selected_pairs.begin(), selected_pairs.end(), removed),
           selected_pairs.end());
       Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
+      data_service.remove_candles(removed);
       if (cancel_pair)
         cancel_pair(removed);
       save_pairs();


### PR DESCRIPTION
## Summary
- add CandleManager::remove_candles to delete all files for a symbol
- expose remove_candles via DataService and call it from control panel when pair is removed

## Testing
- `cmake --build build --target test_candle_manager`
- `./build/test_candle_manager`


------
https://chatgpt.com/codex/tasks/task_e_68a2d71f74a4832790a7b06ca86348ff