### PR TITLE
Add candle reload service and UI control

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -386,6 +386,32 @@ bool CandleManager::remove_candles(const std::string& symbol) const {
     return success;
 }
 
+bool CandleManager::clear_interval(const std::string& symbol, const std::string& interval) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    bool success = true;
+    std::error_code ec;
+    std::filesystem::path csv_path = get_candle_path(symbol, interval);
+    if (std::filesystem::exists(csv_path)) {
+        std::filesystem::remove(csv_path, ec);
+        if (ec) {
+            Logger::instance().warn("Failed to remove " + csv_path.string() + ": " + ec.message());
+            success = false;
+        }
+    }
+
+    ec.clear();
+    std::filesystem::path idx_path = get_index_path(symbol, interval);
+    if (std::filesystem::exists(idx_path)) {
+        std::filesystem::remove(idx_path, ec);
+        if (ec) {
+            Logger::instance().warn("Failed to remove " + idx_path.string() + ": " + ec.message());
+            success = false;
+        }
+    }
+
+    return success;
+}
+
 std::vector<std::string> CandleManager::list_stored_data() const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::vector<std::string> stored_files;

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -25,6 +25,9 @@ public:
     // Removes all files with the given symbol prefix (symbol_*).
     bool remove_candles(const std::string& symbol) const;
 
+    // Removes candle data for a specific symbol and interval.
+    bool clear_interval(const std::string& symbol, const std::string& interval) const;
+
     // Lists all locally stored candle data files (symbol_interval.csv).
     std::vector<std::string> list_stored_data() const;
 

--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -59,6 +59,7 @@ public:
   void append_candles(const std::string &pair, const std::string &interval,
                       const std::vector<Core::Candle> &candles) const;
   bool remove_candles(const std::string &pair) const;
+  bool reload_candles(const std::string &pair, const std::string &interval) const;
   std::vector<std::string> list_stored_data() const;
 
   Core::CandleManager &candle_manager() { return candle_manager_; }

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -24,7 +24,7 @@ void DrawControlPanel(
     std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
     const std::function<void()>& save_pairs,
     const std::vector<std::string>& exchange_pairs,
-    const AppStatus& status,
+    AppStatus& status,
     DataService& data_service,
     const std::function<void(const std::string&)>& cancel_pair);
 


### PR DESCRIPTION
## Summary
- Allow CandleManager to remove specific symbol/interval data files
- Provide DataService::reload_candles to clear and refetch interval data
- Expose Reload buttons in control panel to refresh interval data and log status

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a2dae35a4883279213366c640f129d