### PR TITLE
Add worker thread for fetch queue processing

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <thread>
 
 struct AppStatus {
   float candle_progress = 0.0f;
@@ -43,6 +44,8 @@ private:
   void cleanup();
   void update_next_fetch_time(long long candidate);
   void schedule_retry(long long now_ms, const std::string &msg = "");
+  void start_fetch_thread();
+  void stop_fetch_thread();
 
   std::unique_ptr<AppContext> ctx_;
   DataService data_service_;
@@ -51,4 +54,6 @@ private:
   mutable std::mutex status_mutex_;
   GLFWwindow *window_ = nullptr;
   UiManager ui_manager_;
+  std::thread fetch_thread_;
+  std::atomic<bool> fetch_running_{false};
 };

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -59,6 +59,7 @@ struct AppContext {
     std::chrono::steady_clock::time_point start;
   };
   std::deque<FetchTask> fetch_queue;
+  std::mutex fetch_mutex;
   std::size_t total_fetches = 0;
   std::size_t completed_fetches = 0;
   std::atomic<long long> next_fetch_time{0};


### PR DESCRIPTION
## Summary
- add dedicated worker thread to process queued candle fetches
- guard fetch queue and candle data with mutexes for thread-safe access
- ensure worker thread is started on run and joined during cleanup

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68a3438e4b6c832783bfbf9c88b88aa2