### PR TITLE
fix: use const char pointer for scroll indicator

### DIFF
--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -647,8 +647,9 @@ void DrawChartWindow(
         ImVec2 arrow_pos = ImVec2(
             plot_pos.x - 20,
             plot_pos.y + plot_size.y * 0.5f - ImGui::GetFontSize() * 0.5f);
+        const char *arrow = reinterpret_cast<const char *>(u8"↕");
         ImGui::GetWindowDrawList()->AddText(
-            arrow_pos, IM_COL32(255, 255, 0, 255), u8"↕");
+            arrow_pos, IM_COL32(255, 255, 0, 255), arrow);
         y_scroll_indicator_timer -= ImGui::GetIO().DeltaTime;
       }
       if (!apply_manual_limits) {


### PR DESCRIPTION
## Summary
- replace char8_t literal with const char* for scroll indicator

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GLFW/glfw3.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3531a036483279fecd618ac4e8a80