### PR TITLE
Replace deprecated ImPlot axis flags

### DIFF
--- a/src/ui/chart_window.cpp
+++ b/src/ui/chart_window.cpp
@@ -879,7 +879,7 @@ void DrawChartWindow(
       if (ImPlot::BeginPlot("Volume", ImVec2(-1, -1),
                             ImPlotFlags_NoLegend)) {
         ImPlot::SetupAxes("Time", "Volume",
-                          ImPlotAxisFlags_NoPan | ImPlotAxisFlags_NoZoom,
+                          ImPlotAxisFlags_Lock,
                           ImPlotAxisFlags_None);
         ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
         ImPlot::SetupAxisFormat(ImAxis_X1, "%H:%M:%S");
@@ -900,7 +900,7 @@ void DrawChartWindow(
       if (ImPlot::BeginPlot("Volume", ImVec2(-1, -1),
                             ImPlotFlags_NoLegend)) {
         ImPlot::SetupAxes("Time", "Volume",
-                          ImPlotAxisFlags_NoPan | ImPlotAxisFlags_NoZoom,
+                          ImPlotAxisFlags_Lock,
                           ImPlotAxisFlags_None);
         ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
         ImPlot::SetupAxisFormat(ImAxis_X1, "%H:%M:%S");


### PR DESCRIPTION
## Summary
- use `ImPlotAxisFlags_Lock` instead of removed `ImPlotAxisFlags_NoPan | ImPlotAxisFlags_NoZoom` in chart window volume plot

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a353f732388327bef51b48051961d1