### PR TITLE
Add webview-based ECharts window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(GTest CONFIG REQUIRED)
 find_package(imgui CONFIG QUIET)
 find_package(implot CONFIG QUIET)
 find_package(cpr CONFIG QUIET)
+find_package(webview CONFIG QUIET)
 if(NOT cpr_FOUND)
   message(WARNING "cpr not found, skipping targets that require it")
 endif()
@@ -50,6 +51,11 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/ui/tradingview_style.cpp
     src/ui/ui_manager.cpp
   )
+
+  if(webview_FOUND)
+    target_sources(TradingTerminal PRIVATE src/ui/echarts_window.cpp)
+    target_link_libraries(TradingTerminal PRIVATE webview::webview)
+  endif()
 
   target_sources(TradingTerminal PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp

--- a/resources/chart.html
+++ b/resources/chart.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ECharts</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.2/echarts.min.js"></script>
+  <style>
+    html, body, #chart { height:100%; width:100%; margin:0; }
+  </style>
+</head>
+<body>
+  <div id="chart"></div>
+  <script>
+    const chart = echarts.init(document.getElementById('chart'));
+    chart.setOption({
+      title: { text: 'ECharts' },
+      xAxis: { type: 'category', data: [] },
+      yAxis: { type: 'value' },
+      series: [{ type: 'line', data: [] }]
+    });
+
+    window.receiveFromCpp = function(data) {
+      try {
+        const obj = JSON.parse(data);
+        chart.setOption(obj);
+      } catch (e) {
+        console.error('Invalid JSON from C++', e);
+      }
+    };
+
+    function sendToCpp(obj) {
+      if (window.bridge) {
+        window.bridge(JSON.stringify(obj)).then(function(res) {
+          try {
+            const reply = JSON.parse(res);
+            chart.setOption(reply);
+          } catch (e) {
+            console.error('Invalid JSON from C++ response', e);
+          }
+        });
+      }
+    }
+
+    window.onload = function() {
+      sendToCpp({ request: 'init' });
+    };
+  </script>
+</body>
+</html>

--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -1,0 +1,43 @@
+#include "ui/echarts_window.h"
+
+#include <filesystem>
+#include <utility>
+
+EChartsWindow::EChartsWindow(const std::string &html_path, bool debug)
+    : html_path_(html_path), debug_(debug),
+      view_(std::make_unique<webview::webview>(debug, nullptr)) {}
+
+void EChartsWindow::SetHandler(JsonHandler handler) { handler_ = std::move(handler); }
+
+void EChartsWindow::Show() {
+  if (!view_) {
+    view_ = std::make_unique<webview::webview>(debug_, nullptr);
+  }
+
+  view_->set_title("ECharts");
+  view_->set_size(800, 600, WEBVIEW_HINT_NONE);
+
+  view_->bind("bridge", [this](std::string req) -> std::string {
+    if (handler_) {
+      auto json = nlohmann::json::parse(req, nullptr, false);
+      auto resp = handler_(json);
+      return resp.dump();
+    }
+    return "{}";
+  });
+
+  std::string url = html_path_;
+  if (url.rfind("file://", 0) != 0) {
+    url = std::string("file://") + std::filesystem::absolute(url).string();
+  }
+  view_->navigate(url);
+  view_->run();
+}
+
+void EChartsWindow::SendToJs(const nlohmann::json &data) {
+  if (view_) {
+    std::string script = std::string("window.receiveFromCpp(") + data.dump() + ");";
+    view_->eval(script);
+  }
+}
+

--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <webview.h>
+
+// EChartsWindow embeds a webview to display a chart powered by ECharts and
+// provides a simple JSON-based bridge between C++ and JavaScript.
+class EChartsWindow {
+ public:
+  using JsonHandler =
+      std::function<nlohmann::json(const nlohmann::json &request)>;
+
+  explicit EChartsWindow(const std::string &html_path, bool debug = false);
+
+  // Set handler that will be invoked when JavaScript sends JSON via the bridge.
+  void SetHandler(JsonHandler handler);
+
+  // Show the window and start the event loop.
+  void Show();
+
+  // Send JSON data to the JavaScript side. JS should implement
+  // `window.receiveFromCpp` to receive it.
+  void SendToJs(const nlohmann::json &data);
+
+ private:
+  std::string html_path_;
+  bool debug_;
+  JsonHandler handler_;
+  std::unique_ptr<webview::webview> view_;
+};
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "arrow",
     "glfw3",
     "opengl",
+    "webview",
     "gtest"
   ]
 }


### PR DESCRIPTION
## Summary
- add webview dependency and build hooks
- provide ECharts HTML template with bridge hooks
- implement EChartsWindow C++ wrapper for JSON exchange

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a3662f36bc8327af3e92ecddd8ca74