### PR TITLE
Add JSON export and ECharts integration

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -22,7 +22,10 @@
     window.receiveFromCpp = function(data) {
       try {
         const obj = JSON.parse(data);
-        chart.setOption(obj);
+        chart.setOption({
+          xAxis: { data: obj.x },
+          series: [{ data: obj.y }]
+        });
       } catch (e) {
         console.error('Invalid JSON from C++', e);
       }
@@ -30,14 +33,7 @@
 
     function sendToCpp(obj) {
       if (window.bridge) {
-        window.bridge(JSON.stringify(obj)).then(function(res) {
-          try {
-            const reply = JSON.parse(res);
-            chart.setOption(reply);
-          } catch (e) {
-            console.error('Invalid JSON from C++ response', e);
-          }
-        });
+        window.bridge(JSON.stringify(obj));
       }
     }
 

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -364,6 +364,20 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
     return candles;
 }
 
+nlohmann::json CandleManager::load_candles_json(const std::string& symbol, const std::string& interval) const {
+    auto candles = load_candles(symbol, interval);
+    nlohmann::json result;
+    nlohmann::json x = nlohmann::json::array();
+    nlohmann::json y = nlohmann::json::array();
+    for (const auto& c : candles) {
+        x.push_back(c.open_time);
+        y.push_back(c.close);
+    }
+    result["x"] = std::move(x);
+    result["y"] = std::move(y);
+    return result;
+}
+
 bool CandleManager::remove_candles(const std::string& symbol) const {
     std::lock_guard<std::mutex> lock(mutex_);
     bool success = true;

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <filesystem>
 #include <mutex>
+#include <nlohmann/json.hpp>
 
 namespace Core {
 
@@ -21,6 +22,9 @@ public:
 
     // Loads candles from a CSV file into a vector.
     std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval) const;
+
+    // Loads candles and converts them to a JSON object with arrays "x" and "y".
+    nlohmann::json load_candles_json(const std::string& symbol, const std::string& interval) const;
 
     // Removes all files with the given symbol prefix (symbol_*).
     bool remove_candles(const std::string& symbol) const;

--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <utility>
+#include "core/candle_manager.h"
 
 EChartsWindow::EChartsWindow(const std::string &html_path, bool debug)
     : html_path_(html_path), debug_(debug),
@@ -18,8 +19,13 @@ void EChartsWindow::Show() {
   view_->set_size(800, 600, WEBVIEW_HINT_NONE);
 
   view_->bind("bridge", [this](std::string req) -> std::string {
+    auto json = nlohmann::json::parse(req, nullptr, false);
+    if (json.contains("request") && json["request"] == "init") {
+      Core::CandleManager cm;
+      auto data = cm.load_candles_json("BTCUSDT", "1m");
+      SendToJs(data);
+    }
     if (handler_) {
-      auto json = nlohmann::json::parse(req, nullptr, false);
       auto resp = handler_(json);
       return resp.dump();
     }


### PR DESCRIPTION
## Summary
- Add `load_candles_json` to CandleManager for nlohmann::json output
- Send candle JSON to ECharts via webview and update chart handler

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: static assertion when building tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a3707835bc8327a06bf000ef968adc