### PR TITLE
Add ECharts dock panel and JS bridge

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -9,9 +9,18 @@
   </style>
 </head>
 <body>
-  <div id="chart"></div>
+  <select id="interval">
+    <option value="1m">1m</option>
+    <option value="5m">5m</option>
+    <option value="1h">1h</option>
+  </select>
+  <div id="chart" style="height:90%;"></div>
   <script>
     const chart = echarts.init(document.getElementById('chart'));
+    const intervalSel = document.getElementById('interval');
+    intervalSel.addEventListener('change', function() {
+      sendToCpp({ interval: intervalSel.value });
+    });
     chart.setOption({
       title: { text: 'ECharts' },
       xAxis: { type: 'category', data: [] },
@@ -22,10 +31,15 @@
     window.receiveFromCpp = function(data) {
       try {
         const obj = JSON.parse(data);
-        chart.setOption({
-          xAxis: { data: obj.x },
-          series: [{ data: obj.y }]
-        });
+        if (obj.x && obj.y) {
+          chart.setOption({
+            xAxis: { data: obj.x },
+            series: [{ data: obj.y }]
+          });
+        }
+        if (obj.interval) {
+          intervalSel.value = obj.interval;
+        }
       } catch (e) {
         console.error('Invalid JSON from C++', e);
       }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -75,7 +75,11 @@ bool App::init_window() {
   return true;
 }
 
-void App::setup_imgui() { ui_manager_.setup(window_); }
+void App::setup_imgui() {
+  ui_manager_.setup(window_);
+  ui_manager_.set_interval_callback(
+      [this](const std::string &iv) { this->ctx_->selected_interval = iv; });
+}
 
 void App::load_config() {
   auto cfg = Config::ConfigManager::load("config.json");
@@ -475,6 +479,8 @@ void App::render_ui() {
     DrawAnalyticsWindow(this->ctx_->all_candles, this->ctx_->active_pair, this->ctx_->selected_interval);
     DrawJournalWindow(journal_service_.journal());
   }
+
+  ui_manager_.draw_echarts_panel(this->ctx_->selected_interval);
 
   ImGui::Begin("Backtest");
   ImGui::Text("Strategy: %s", this->ctx_->strategy.c_str());

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,12 +1,32 @@
 #pragma once
 
-#include <GLFW/glfw3.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
 
-// Manages ImGui initialization and per-frame rendering.
+struct GLFWwindow;
+
+class EChartsWindow;
+
+// Manages ImGui initialization and per-frame rendering and hosts auxiliary
+// UI panels such as the ECharts webview container.
 class UiManager {
 public:
   bool setup(GLFWwindow *window);
   void begin_frame();
+  // Draw docked panels each frame. Currently hosts the ECharts window and
+  // forwards interval changes to the JavaScript side.
+  void draw_echarts_panel(const std::string &selected_interval);
+  // Set callback to be invoked when the JS side notifies about a new interval
+  // selection.
+  void set_interval_callback(std::function<void(const std::string &)> cb);
   void end_frame(GLFWwindow *window);
   void shutdown();
+
+private:
+  std::unique_ptr<EChartsWindow> echarts_window_;
+  std::thread echarts_thread_;
+  std::string current_interval_;
+  std::function<void(const std::string &)> on_interval_changed_;
 };


### PR DESCRIPTION
## Summary
- add docked ImGui panel that embeds ECharts webview and forwards interval changes
- bridge interval selection events between ImGui and JavaScript
- expose interval selector inside chart.html for JS->C++ communication

## Testing
- `cmake --build build` *(fails: static assertion in std::format while building tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3754faf308327beb01899ae7dc443