### PR TITLE
Use candlestick serializer in UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_compile_definitions(NOMINMAX)
 add_compile_definitions(GTEST_HAS_STD_FORMAT=0)
+add_compile_definitions(GTEST_HAS_STD_WSTRING=0)
 
 option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -364,19 +364,6 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
     return candles;
 }
 
-nlohmann::json CandleManager::load_candles_json(const std::string& symbol, const std::string& interval) const {
-    auto candles = load_candles(symbol, interval);
-    nlohmann::json result;
-    nlohmann::json x = nlohmann::json::array();
-    nlohmann::json y = nlohmann::json::array();
-    for (const auto& c : candles) {
-        x.push_back(c.open_time);
-        y.push_back(c.close);
-    }
-    result["x"] = std::move(x);
-    result["y"] = std::move(y);
-    return result;
-}
 
 bool CandleManager::remove_candles(const std::string& symbol) const {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <filesystem>
 #include <mutex>
-#include <nlohmann/json.hpp>
 
 namespace Core {
 
@@ -22,9 +21,6 @@ public:
 
     // Loads candles from a CSV file into a vector.
     std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval) const;
-
-    // Loads candles and converts them to a JSON object with arrays "x" and "y".
-    nlohmann::json load_candles_json(const std::string& symbol, const std::string& interval) const;
 
     // Removes all files with the given symbol prefix (symbol_*).
     bool remove_candles(const std::string& symbol) const;

--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <utility>
 #include "core/candle_manager.h"
+#include "ui/echarts_serializer.h"
 
 EChartsWindow::EChartsWindow(const std::string &html_path, bool debug)
     : html_path_(html_path), debug_(debug),
@@ -22,7 +23,8 @@ void EChartsWindow::Show() {
     auto json = nlohmann::json::parse(req, nullptr, false);
     if (json.contains("request") && json["request"] == "init") {
       Core::CandleManager cm;
-      auto data = cm.load_candles_json("BTCUSDT", "1m");
+      auto candles = cm.load_candles("BTCUSDT", "1m");
+      auto data = SerializeCandles(candles);
       SendToJs(data);
     }
     if (handler_) {


### PR DESCRIPTION
## Summary
- Replace CandleManager's ad-hoc JSON builder with SerializeCandles in EChartsWindow
- Drop JSON-specific helper from CandleManager interface
- Disable wide-string formatting in gtest via CMake to avoid unused wide formatting

## Testing
- `cmake --build build` *(fails: static assertion on std::formatter during test_echarts_serialization build)*

------
https://chatgpt.com/codex/tasks/task_e_68a38492e2588327b4a929958ddc7ca8