### PR TITLE
Remove obsolete cache invalidation calls

### DIFF
--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -141,7 +141,6 @@ void DrawControlPanel(
                     last_time = c.open_time;
                   }
                 }
-                InvalidateCache(symbol, interval);
               }
             } else if (fetched.error != FetchError::None) {
               failed = true;
@@ -289,7 +288,6 @@ void DrawControlPanel(
           }
           if (status.log.size() > 50)
             status.log.pop_front();
-          InvalidateCache(it->name, interval);
         }
       }
       ++it;


### PR DESCRIPTION
## Summary
- remove legacy `InvalidateCache` calls from control panel

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a38e174dbc83279ab3bec56865ece6