### PR TITLE
Refactor control panel rendering into modular functions

### DIFF
--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -30,6 +30,8 @@ const ImVec4 COLOR_LOW = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
 const ImVec4 COLOR_MED = ImVec4(1.0f, 1.0f, 0.0f, 1.0f);
 const ImVec4 COLOR_HIGH = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);
 
+
+// Format milliseconds since epoch into a dd.mm string or "-".
 std::string format_date(long long ms) {
   if (ms == 0)
     return "-";
@@ -40,20 +42,214 @@ std::string format_date(long long ms) {
     return std::string(buf);
   return "-";
 }
+
+struct TooltipStat {
+  std::string interval;
+  size_t count;
+  double volume;
+  std::string start;
+  std::string end;
+};
+
+// Load candle history for a symbol across multiple intervals.
+bool LoadInitialCandles(
+    DataService &data_service, const std::string &symbol,
+    const std::vector<std::string> &intervals,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> &all_candles,
+    std::string &load_error) {
+  bool failed = false;
+  for (const auto &interval : intervals) {
+    auto candles = data_service.load_candles(symbol, interval);
+    long long last_time = candles.empty() ? 0 : candles.back().open_time;
+    if (candles.size() < EXPECTED_CANDLES) {
+      int missing = EXPECTED_CANDLES - static_cast<int>(candles.size());
+      auto fetched = data_service.fetch_klines(symbol, interval, missing);
+      if (fetched.error == FetchError::None && !fetched.candles.empty()) {
+        auto interval_ms = parse_interval(interval).count();
+        std::vector<Candle> to_append;
+        long long expected = last_time + interval_ms;
+        for (const auto &c : fetched.candles) {
+          if (c.open_time > expected) {
+            long long gap_end = c.open_time - interval_ms;
+            auto gap_res = data_service.fetch_range(symbol, interval, expected,
+                                                    gap_end);
+            if (gap_res.error == FetchError::None &&
+                !gap_res.candles.empty()) {
+              to_append.insert(to_append.end(), gap_res.candles.begin(),
+                               gap_res.candles.end());
+              load_error.clear();
+            } else {
+              failed = true;
+              load_error = "Gap load failed for " + symbol + " " + interval +
+                           ": " + gap_res.message;
+            }
+            expected = gap_end + interval_ms;
+          }
+          if (c.open_time >= expected) {
+            to_append.push_back(c);
+            expected = c.open_time + interval_ms;
+          }
+        }
+        if (!to_append.empty()) {
+          data_service.append_candles(symbol, interval, to_append);
+          for (const auto &c : to_append) {
+            if (c.open_time > last_time) {
+              candles.push_back(c);
+              last_time = c.open_time;
+            }
+          }
+        }
+      } else if (fetched.error != FetchError::None) {
+        failed = true;
+        load_error =
+            "Load failed for " + symbol + " " + interval + ": " + fetched.message;
+      }
+    }
+    if (candles.empty()) {
+      failed = true;
+    } else {
+      all_candles[symbol][interval] = candles;
+    }
+  }
+  if (failed && load_error.empty())
+    load_error = "Failed to load " + symbol;
+  return !failed;
+}
+
+// Render a single pair row with stats and controls. Returns true if the pair
+// should be removed from the list.
+bool RenderPairRow(
+    std::vector<PairItem> &pairs, PairItem &item,
+    std::vector<std::string> &selected_pairs, std::string &active_pair,
+    const std::vector<std::string> &intervals, std::string &selected_interval,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> &all_candles,
+    const std::function<void()> &save_pairs, DataService &data_service,
+    AppStatus &status,
+    const std::function<void(const std::string &)> &cancel_pair) {
+  std::string checkbox_id = item.name + "##checkbox_" + item.name;
+  if (ImGui::Checkbox(checkbox_id.c_str(), &item.visible)) {
+    if (!item.visible && active_pair == item.name) {
+      auto new_active =
+          std::find_if(pairs.begin(), pairs.end(),
+                       [](const PairItem &p) { return p.visible; });
+      active_pair = new_active != pairs.end() ? new_active->name : std::string();
+    } else if (item.visible && active_pair.empty()) {
+      active_pair = item.name;
+    }
+  }
+
+  bool missing_data = false;
+  std::vector<TooltipStat> stats;
+  size_t sel_count = 0;
+  std::string sel_start = "-";
+  std::string sel_end = "-";
+  for (const auto &interval : intervals) {
+    const auto &candles = all_candles[item.name][interval];
+    size_t count = candles.size();
+    double volume =
+        std::accumulate(candles.begin(), candles.end(), 0.0,
+                        [](double sum, const Candle &c) { return sum + c.volume; });
+    long long min_t = 0;
+    long long max_t = 0;
+    if (!candles.empty()) {
+      auto [min_it, max_it] = std::minmax_element(
+          candles.begin(), candles.end(),
+          [](const Candle &a, const Candle &b) { return a.open_time < b.open_time; });
+      min_t = min_it->open_time;
+      max_t = max_it->open_time;
+    } else {
+      missing_data = true;
+    }
+    std::string start = format_date(min_t);
+    std::string end = format_date(max_t);
+    stats.push_back({interval, count, volume, start, end});
+    if (interval == selected_interval) {
+      sel_count = count;
+      sel_start = start;
+      sel_end = end;
+    }
+  }
+
+  const char *emoji = EMOJI_LOW;
+  ImVec4 color = COLOR_LOW;
+  if (sel_count >= THRESHOLD_MED) {
+    emoji = EMOJI_HIGH;
+    color = COLOR_HIGH;
+  } else if (sel_count >= THRESHOLD_LOW) {
+    emoji = EMOJI_MED;
+    color = COLOR_MED;
+  }
+  std::string label =
+      sel_start + "–" + sel_end + " (" + std::to_string(sel_count) + ")";
+  ImGui::SameLine();
+  ImGui::Text("%s %s", emoji, label.c_str());
+  ImGui::SameLine();
+  float progress = EXPECTED_CANDLES
+                       ? static_cast<float>(sel_count) / EXPECTED_CANDLES
+                       : 0.0f;
+  ImGui::PushStyleColor(ImGuiCol_PlotHistogram, color);
+  ImGui::ProgressBar(progress, ImVec2(100.0f, 0.0f));
+  ImGui::PopStyleColor();
+
+  if (ImGui::IsItemHovered()) {
+    ImGui::BeginTooltip();
+    for (const auto &s : stats) {
+      ImGui::Text("%s: %zu candles, vol %.2f, %s-%s", s.interval.c_str(),
+                  s.count, s.volume, s.start.c_str(), s.end.c_str());
+    }
+    ImGui::EndTooltip();
+  }
+  if (missing_data) {
+    ImGui::SameLine();
+    ImGui::TextColored(COLOR_LOW, "!");
+  }
+  ImGui::SameLine();
+  if (ImGui::SmallButton((std::string("X##remove_") + item.name).c_str())) {
+    all_candles.erase(item.name);
+    if (active_pair == item.name) {
+      auto new_active =
+          std::find_if(pairs.begin(), pairs.end(),
+                       [](const PairItem &p) { return p.visible; });
+      active_pair = new_active != pairs.end() ? new_active->name : std::string();
+    }
+    selected_pairs.erase(std::remove(selected_pairs.begin(), selected_pairs.end(),
+                                     item.name),
+                         selected_pairs.end());
+    Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
+    data_service.remove_candles(item.name);
+    if (cancel_pair)
+      cancel_pair(item.name);
+    save_pairs();
+    return true;
+  }
+
+  for (const auto &interval : intervals) {
+    ImGui::SameLine();
+    if (ImGui::SmallButton(
+            (std::string("Reload##") + item.name + "_" + interval).c_str())) {
+      bool ok = data_service.reload_candles(item.name, interval);
+      if (ok) {
+        all_candles[item.name][interval] =
+            data_service.load_candles(item.name, interval);
+        status.log.push_back("Reloaded " + item.name + " " + interval);
+      } else {
+        status.log.push_back("Reload failed for " + item.name + " " + interval);
+      }
+      if (status.log.size() > 50)
+        status.log.pop_front();
+    }
+  }
+  return false;
+}
 } // namespace
 
-void DrawControlPanel(
+// Render controls to load new pairs from the exchange.
+static void RenderLoadControls(
     std::vector<PairItem> &pairs, std::vector<std::string> &selected_pairs,
-    std::string &active_pair, const std::vector<std::string> &intervals,
-    std::string &selected_interval,
-    std::map<std::string, std::map<std::string, std::vector<Candle>>>
-        &all_candles,
+    const std::vector<std::string> &intervals,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> &all_candles,
     const std::function<void()> &save_pairs,
-    const std::vector<std::string> &exchange_pairs, AppStatus &status,
-    DataService &data_service,
-    const std::function<void(const std::string &)> &cancel_pair) {
-  ImGui::Begin("Control Panel");
-
+    const std::vector<std::string> &exchange_pairs, DataService &data_service) {
   ImGui::Text("Select pairs to load:");
   static std::string load_error;
 
@@ -87,75 +283,20 @@ void DrawControlPanel(
     ImGui::EndCombo();
   }
   ImGui::SameLine();
-  if (ImGui::Button("Load Selected")) {
-    if (!sorted_pairs.empty()) {
-      std::string symbol = sorted_pairs[selected_idx];
-      if (std::none_of(pairs.begin(), pairs.end(),
-                       [&](const PairItem &p) { return p.name == symbol; })) {
-        pairs.push_back({symbol, true});
-        save_pairs();
-        if (std::find(selected_pairs.begin(), selected_pairs.end(), symbol) ==
-            selected_pairs.end()) {
-          selected_pairs.push_back(symbol);
-          Config::ConfigManager::save_selected_pairs("config.json",
-                                                     selected_pairs);
-        }
-        bool failed = false;
-        for (const auto &interval : intervals) {
-          auto candles = data_service.load_candles(symbol, interval);
-          long long last_time = candles.empty() ? 0 : candles.back().open_time;
-          if (candles.size() < EXPECTED_CANDLES) {
-            int missing = EXPECTED_CANDLES - static_cast<int>(candles.size());
-            auto fetched = data_service.fetch_klines(symbol, interval, missing);
-            if (fetched.error == FetchError::None && !fetched.candles.empty()) {
-              auto interval_ms = parse_interval(interval).count();
-              std::vector<Candle> to_append;
-              long long expected = last_time + interval_ms;
-              for (const auto &c : fetched.candles) {
-                if (c.open_time > expected) {
-                  long long gap_end = c.open_time - interval_ms;
-                  auto gap_res = data_service.fetch_range(symbol, interval,
-                                                          expected, gap_end);
-                  if (gap_res.error == FetchError::None &&
-                      !gap_res.candles.empty()) {
-                    to_append.insert(to_append.end(), gap_res.candles.begin(),
-                                     gap_res.candles.end());
-                    load_error.clear();
-                  } else {
-                    failed = true;
-                    load_error = "Gap load failed for " + symbol +
-                                 " " + interval + ": " + gap_res.message;
-                  }
-                  expected = gap_end + interval_ms;
-                }
-                if (c.open_time >= expected) {
-                  to_append.push_back(c);
-                  expected = c.open_time + interval_ms;
-                }
-              }
-              if (!to_append.empty()) {
-                data_service.append_candles(symbol, interval, to_append);
-                for (const auto &c : to_append) {
-                  if (c.open_time > last_time) {
-                    candles.push_back(c);
-                    last_time = c.open_time;
-                  }
-                }
-              }
-            } else if (fetched.error != FetchError::None) {
-              failed = true;
-              load_error = "Load failed for " + symbol + " " + interval +
-                           ": " + fetched.message;
-            }
-          }
-          if (candles.empty()) {
-            failed = true;
-          } else {
-            all_candles[symbol][interval] = candles;
-          }
-        }
-        if (failed && load_error.empty())
-          load_error = "Failed to load " + symbol;
+  if (ImGui::Button("Load Selected") && !sorted_pairs.empty()) {
+    std::string symbol = sorted_pairs[selected_idx];
+    if (std::none_of(pairs.begin(), pairs.end(),
+                     [&](const PairItem &p) { return p.name == symbol; })) {
+      pairs.push_back({symbol, true});
+      save_pairs();
+      if (std::find(selected_pairs.begin(), selected_pairs.end(), symbol) ==
+          selected_pairs.end()) {
+        selected_pairs.push_back(symbol);
+        Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
+      }
+      if (!LoadInitialCandles(data_service, symbol, intervals, all_candles,
+                              load_error)) {
+        // load_error already set inside helper
       }
     }
   }
@@ -163,137 +304,30 @@ void DrawControlPanel(
   if (!load_error.empty()) {
     ImGui::Text("%s", load_error.c_str());
   }
+}
 
+// Render the list of loaded pairs with statistics and controls.
+static void RenderPairSelector(
+    std::vector<PairItem> &pairs, std::vector<std::string> &selected_pairs,
+    std::string &active_pair, const std::vector<std::string> &intervals,
+    std::string &selected_interval,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> &all_candles,
+    const std::function<void()> &save_pairs, DataService &data_service,
+    AppStatus &status,
+    const std::function<void(const std::string &)> &cancel_pair) {
   for (auto it = pairs.begin(); it != pairs.end();) {
-    std::string checkbox_id = it->name + "##checkbox_" + it->name;
-    if (ImGui::Checkbox(checkbox_id.c_str(), &it->visible)) {
-      if (!it->visible && active_pair == it->name) {
-        auto new_active =
-            std::find_if(pairs.begin(), pairs.end(),
-                         [](const PairItem &p) { return p.visible; });
-        active_pair =
-            new_active != pairs.end() ? new_active->name : std::string();
-      } else if (it->visible && active_pair.empty()) {
-        active_pair = it->name;
-      }
-    }
-
-    bool missing_data = false;
-    struct TooltipStat {
-      std::string interval;
-      size_t count;
-      double volume;
-      std::string start;
-      std::string end;
-    };
-    std::vector<TooltipStat> stats;
-    size_t sel_count = 0;
-    std::string sel_start = "-";
-    std::string sel_end = "-";
-    for (const auto &interval : intervals) {
-      const auto &candles = all_candles[it->name][interval];
-      size_t count = candles.size();
-      double volume = std::accumulate(
-          candles.begin(), candles.end(), 0.0,
-          [](double sum, const Candle &c) { return sum + c.volume; });
-      long long min_t = 0;
-      long long max_t = 0;
-      if (!candles.empty()) {
-        auto [min_it, max_it] =
-            std::minmax_element(candles.begin(), candles.end(),
-                                [](const Candle &a, const Candle &b) {
-                                  return a.open_time < b.open_time;
-                                });
-        min_t = min_it->open_time;
-        max_t = max_it->open_time;
-      } else {
-        missing_data = true;
-      }
-      std::string start = format_date(min_t);
-      std::string end = format_date(max_t);
-      stats.push_back({interval, count, volume, start, end});
-      if (interval == selected_interval) {
-        sel_count = count;
-        sel_start = start;
-        sel_end = end;
-      }
-    }
-
-    const char *emoji = EMOJI_LOW;
-    ImVec4 color = COLOR_LOW;
-    if (sel_count >= THRESHOLD_MED) {
-      emoji = EMOJI_HIGH;
-      color = COLOR_HIGH;
-    } else if (sel_count >= THRESHOLD_LOW) {
-      emoji = EMOJI_MED;
-      color = COLOR_MED;
-    }
-    std::string label =
-        sel_start + "–" + sel_end + " (" + std::to_string(sel_count) + ")";
-    ImGui::SameLine();
-    ImGui::Text("%s %s", emoji, label.c_str());
-    ImGui::SameLine();
-    float progress = EXPECTED_CANDLES
-                         ? static_cast<float>(sel_count) / EXPECTED_CANDLES
-                         : 0.0f;
-    ImGui::PushStyleColor(ImGuiCol_PlotHistogram, color);
-    ImGui::ProgressBar(progress, ImVec2(100.0f, 0.0f));
-    ImGui::PopStyleColor();
-
-    if (ImGui::IsItemHovered()) {
-      ImGui::BeginTooltip();
-      for (const auto &s : stats) {
-        ImGui::Text("%s: %zu candles, vol %.2f, %s-%s", s.interval.c_str(),
-                    s.count, s.volume, s.start.c_str(), s.end.c_str());
-      }
-      ImGui::EndTooltip();
-    }
-    if (missing_data) {
-      ImGui::SameLine();
-      ImGui::TextColored(COLOR_LOW, "!");
-    }
-    ImGui::SameLine();
-    if (ImGui::SmallButton((std::string("X##remove_") + it->name).c_str())) {
-      std::string removed = it->name;
+    if (RenderPairRow(pairs, *it, selected_pairs, active_pair, intervals,
+                      selected_interval, all_candles, save_pairs, data_service,
+                      status, cancel_pair)) {
       it = pairs.erase(it);
-      all_candles.erase(removed);
-      if (active_pair == removed) {
-        auto new_active =
-            std::find_if(pairs.begin(), pairs.end(),
-                         [](const PairItem &p) { return p.visible; });
-        active_pair =
-            new_active != pairs.end() ? new_active->name : std::string();
-      }
-      selected_pairs.erase(
-          std::remove(selected_pairs.begin(), selected_pairs.end(), removed),
-          selected_pairs.end());
-      Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
-      data_service.remove_candles(removed);
-      if (cancel_pair)
-        cancel_pair(removed);
-      save_pairs();
     } else {
-      for (const auto &interval : intervals) {
-        ImGui::SameLine();
-        if (ImGui::SmallButton(
-                (std::string("Reload##") + it->name + "_" + interval).c_str())) {
-          bool ok = data_service.reload_candles(it->name, interval);
-          if (ok) {
-            all_candles[it->name][interval] =
-                data_service.load_candles(it->name, interval);
-            status.log.push_back("Reloaded " + it->name + " " + interval);
-          } else {
-            status.log.push_back("Reload failed for " + it->name + " " +
-                                  interval);
-          }
-          if (status.log.size() > 50)
-            status.log.pop_front();
-        }
-      }
       ++it;
     }
   }
+}
 
+// Render application status information and recent log messages.
+static void RenderStatusPane(AppStatus &status) {
   ImGui::Separator();
   ImGui::Text("Status");
   ImGui::Text("Candles: %.0f%%", status.candle_progress * 100.0f);
@@ -307,6 +341,25 @@ void DrawControlPanel(
     }
     ImGui::EndListBox();
   }
+}
+
+void DrawControlPanel(
+    std::vector<PairItem> &pairs, std::vector<std::string> &selected_pairs,
+    std::string &active_pair, const std::vector<std::string> &intervals,
+    std::string &selected_interval,
+    std::map<std::string, std::map<std::string, std::vector<Candle>>> &all_candles,
+    const std::function<void()> &save_pairs,
+    const std::vector<std::string> &exchange_pairs, AppStatus &status,
+    DataService &data_service,
+    const std::function<void(const std::string &)> &cancel_pair) {
+  ImGui::Begin("Control Panel");
+
+  RenderLoadControls(pairs, selected_pairs, intervals, all_candles, save_pairs,
+                     exchange_pairs, data_service);
+  RenderPairSelector(pairs, selected_pairs, active_pair, intervals,
+                     selected_interval, all_candles, save_pairs, data_service,
+                     status, cancel_pair);
+  RenderStatusPane(status);
 
   ImGui::End();
 }


### PR DESCRIPTION
## Summary
- Extract load, pair selection, and status rendering into `RenderLoadControls`, `RenderPairSelector`, and `RenderStatusPane`
- Move candle loading and per-pair rendering logic into anonymous namespace helpers
- Document each helper and keep functions concise

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a390862d208327b347461ce77fdc69