### PR TITLE
Handle missing imgui and webview dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,18 @@ add_compile_definitions(GTEST_HAS_STD_WSTRING=0)
 option(BUILD_TRADING_TERMINAL "Build the TradingTerminal application" ON)
 
 find_package(GTest CONFIG REQUIRED)
-  find_package(imgui CONFIG QUIET)
+find_package(imgui CONFIG QUIET)
+if(NOT imgui_FOUND)
+  message(WARNING "imgui not found, using bundled sources")
+  add_library(imgui
+    third_party/imgui/imgui.cpp
+    third_party/imgui/imgui_draw.cpp
+    third_party/imgui/imgui_tables.cpp
+    third_party/imgui/imgui_widgets.cpp
+  )
+  target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui)
+  add_library(imgui::imgui ALIAS imgui)
+endif()
 find_package(cpr CONFIG QUIET)
 find_package(webview CONFIG QUIET)
 if(NOT cpr_FOUND)
@@ -47,12 +58,14 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
       src/ui/analytics_window.cpp
       src/ui/journal_window.cpp
       src/ui/ui_manager.cpp
-      src/ui/echarts_window.cpp
       src/ui/echarts_serializer.cpp
   )
 
     if(webview_FOUND)
+      target_sources(TradingTerminal PRIVATE src/ui/echarts_window.cpp)
       target_link_libraries(TradingTerminal PRIVATE webview::webview)
+    else()
+      message(WARNING "webview not found, disabling ECharts window")
     endif()
 
   target_sources(TradingTerminal PRIVATE

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Standalone C++ trading terminal using ImGui with an embedded chart powered by [A
 ## Сборка
 
 1. Установите [vcpkg](https://github.com/microsoft/vcpkg) и настройте переменную `CMAKE_TOOLCHAIN_FILE` на `scripts/buildsystems/vcpkg.cmake`.
+   Опциональные зависимости:
+   - `imgui` — используется из пакета, если он установлен; иначе проект собирает встроенные исходники из `third_party/imgui`.
+   - `webview` — обеспечивает окно графиков на ECharts. При отсутствии пакета сборка продолжится без него, и окно графиков будет отключено.
 2. Выполните конфигурацию проекта:
    ```
    cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake


### PR DESCRIPTION
## Summary
- add bundled imgui fallback when the package is missing
- guard ECharts window sources and webview linking behind `webview_FOUND`
- document optional `imgui` and `webview` dependencies in build instructions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a3928c52cc8327ba97ea278fc362a1