### PR TITLE
refactor: extract fill_missing utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
       src/core/candle_manager.cpp
     src/core/data_fetcher.cpp
     src/core/interval_utils.cpp
+    src/core/candle_utils.cpp
     src/core/net/token_bucket_rate_limiter.cpp
     src/core/net/cpr_http_client.cpp
     src/core/backtester.cpp
@@ -126,6 +127,7 @@ add_executable(test_data_fetcher
   tests/test_data_fetcher.cpp
   src/core/data_fetcher.cpp
   src/core/interval_utils.cpp
+  src/core/candle_utils.cpp
   src/candle.cpp
   src/core/logger.cpp
 )

--- a/src/core/candle_utils.cpp
+++ b/src/core/candle_utils.cpp
@@ -1,0 +1,29 @@
+#include "candle_utils.h"
+
+#include <utility>
+
+namespace Core {
+
+void fill_missing(std::vector<Candle> &candles, long long interval_ms) {
+  if (candles.size() < 2 || interval_ms <= 0)
+    return;
+  std::vector<Candle> filled;
+  filled.reserve(candles.size());
+  for (std::size_t i = 0; i + 1 < candles.size(); ++i) {
+    const auto &cur = candles[i];
+    const auto &next = candles[i + 1];
+    filled.push_back(cur);
+    long long expected = cur.open_time + interval_ms;
+    while (expected < next.open_time) {
+      filled.emplace_back(expected, cur.close, cur.close, cur.close, cur.close,
+                         0.0, expected + interval_ms - 1, 0.0, 0, 0.0, 0.0,
+                         0.0);
+      expected += interval_ms;
+    }
+  }
+  filled.push_back(candles.back());
+  candles = std::move(filled);
+}
+
+} // namespace Core
+

--- a/src/core/candle_utils.h
+++ b/src/core/candle_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "candle.h"
+#include <vector>
+
+namespace Core {
+
+void fill_missing(std::vector<Candle> &candles, long long interval_ms);
+
+} // namespace Core
+

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -2,6 +2,7 @@
 
 #include "core/logger.h"
 #include "interval_utils.h"
+#include "candle_utils.h"
 #include <algorithm>
 #include <chrono>
 #include <future>
@@ -10,27 +11,6 @@
 #include <thread>
 
 namespace {
-
-
-void fill_missing(std::vector<Core::Candle> &candles, long long interval_ms) {
-  if (candles.size() < 2 || interval_ms <= 0)
-    return;
-  std::vector<Core::Candle> filled;
-  filled.reserve(candles.size());
-  for (std::size_t i = 0; i + 1 < candles.size(); ++i) {
-    const auto &cur = candles[i];
-    const auto &next = candles[i + 1];
-    filled.push_back(cur);
-    long long expected = cur.open_time + interval_ms;
-    while (expected < next.open_time) {
-      filled.emplace_back(expected, cur.close, cur.close, cur.close, cur.close,
-                         0.0, expected + interval_ms - 1, 0.0, 0, 0.0, 0.0, 0.0);
-      expected += interval_ms;
-    }
-  }
-  filled.push_back(candles.back());
-  candles = std::move(filled);
-}
 
 std::string to_gate_symbol(const std::string &symbol) {
   if (symbol.size() < 6)

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -3,6 +3,7 @@
 #include "core/candle_manager.h"
 #include "core/interval_utils.h"
 #include "core/logger.h"
+#include "core/candle_utils.h"
 #include "config_manager.h"
 
 #include <algorithm>
@@ -10,27 +11,6 @@
 #include <thread>
 
 namespace {
-
-void fill_missing(std::vector<Core::Candle> &candles, long long interval_ms) {
-  if (candles.size() < 2 || interval_ms <= 0)
-    return;
-  std::vector<Core::Candle> filled;
-  filled.reserve(candles.size());
-  for (std::size_t i = 0; i + 1 < candles.size(); ++i) {
-    const auto &cur = candles[i];
-    const auto &next = candles[i + 1];
-    filled.push_back(cur);
-    long long expected = cur.open_time + interval_ms;
-    while (expected < next.open_time) {
-      filled.emplace_back(expected, cur.close, cur.close, cur.close, cur.close,
-                         0.0, expected + interval_ms - 1, 0.0, 0, 0.0, 0.0,
-                         0.0);
-      expected += interval_ms;
-    }
-  }
-  filled.push_back(candles.back());
-  candles = std::move(filled);
-}
 
 std::string to_gate_symbol(const std::string &symbol) {
   if (symbol.size() < 6)
@@ -257,7 +237,7 @@ Core::KlinesResult DataService::fetch_range(
     }
   }
 
-  fill_missing(result, interval_ms);
+  Core::fill_missing(result, interval_ms);
   return {Core::FetchError::None, http_status, "", result};
 }
 


### PR DESCRIPTION
## Summary
- add reusable candle_utils with fill_missing helper
- use candle_utils in data_fetcher and data_service
- update build to compile and test against new utility

## Testing
- `cmake --build build --target test_data_fetcher`
- `cd build && ctest -R test_data_fetcher --output-on-failure && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68a396c21c248327bbb6715e303771b0