### PR TITLE
Define UiManager destructor out-of-line

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -1,15 +1,15 @@
 #include "ui_manager.h"
 
-#include "imgui.h"
-#include "imgui_impl_glfw.h"
-#include "imgui_impl_opengl3.h"
 #include <GLFW/glfw3.h>
-#include "ui/echarts_window.h"
-#include "core/candle_manager.h"
-
 #include <nlohmann/json.hpp>
 #include <thread>
 #include <utility>
+
+#include "core/candle_manager.h"
+#include "imgui.h"
+#include "imgui_impl_glfw.h"
+#include "imgui_impl_opengl3.h"
+#include "ui/echarts_window.h"
 
 UiManager::~UiManager() = default;
 


### PR DESCRIPTION
## Summary
- Reorganized includes in `UiManager` implementation and keep destructor defined out-of-line as default

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a470273e08832799560bbbb77aa783