### PR TITLE
Include EChartsWindow header in UiManager

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <thread>
 
-struct GLFWwindow;
+#include "ui/echarts_window.h"
 
-class EChartsWindow;
+struct GLFWwindow;
 
 // Manages ImGui initialization and per-frame rendering and hosts auxiliary
 // UI panels such as the ECharts webview container.


### PR DESCRIPTION
## Summary
- Include `ui/echarts_window.h` directly in `UiManager`
- Remove obsolete forward declaration of `EChartsWindow`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a47b46f7ec83279cc72b79e52c4e18