### PR TITLE
Warn when chart resources missing and document placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Standalone C++ trading terminal using ImGui with an embedded chart powered by [A
    ```
    cp -r resources third_party/echarts build/
    ```
+   После копирования убедитесь, что файлы `resources/chart.html` и
+   `third_party/echarts/echarts.min.js` находятся рядом с исполняемым
+   файлом, например:
+
+   ```
+   build/
+   ├── TradingTerminal
+   ├── resources/
+   │   └── chart.html
+   └── third_party/
+       └── echarts/
+           └── echarts.min.js
+   ```
 
 ## График
 

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -28,10 +28,18 @@ bool UiManager::setup(GLFWwindow *window) {
   const std::filesystem::path html_path{"resources/chart.html"};
   const std::filesystem::path js_path{"../third_party/echarts/echarts.min.js"};
 
+  const auto html_abs = std::filesystem::absolute(html_path);
+  const auto js_abs = std::filesystem::absolute(js_path);
+  Core::Logger::instance().info("Checking chart resources at " +
+                                html_abs.string() + " and " +
+                                js_abs.string());
+
   resources_available_ =
-      std::filesystem::exists(html_path) && std::filesystem::exists(js_path);
+      std::filesystem::exists(html_abs) && std::filesystem::exists(js_abs);
   if (!resources_available_) {
-    Core::Logger::instance().error("Chart resources missing");
+    Core::Logger::instance().error("Chart resources missing. Checked '" +
+                                   html_abs.string() + "' and '" +
+                                   js_abs.string() + "'");
   } else {
     echarts_window_ = std::make_unique<EChartsWindow>(html_path.string());
 
@@ -66,7 +74,8 @@ void UiManager::draw_echarts_panel(const std::string &selected_interval) {
   ImGui::Begin("Chart");
 #if USE_WEBVIEW
   if (!resources_available_) {
-    ImGui::Text("Chart resources missing");
+    ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+                       "Chart resources missing");
   } else if (echarts_window_) {
     if (selected_interval != current_interval_) {
       echarts_window_->SendToJs(


### PR DESCRIPTION
## Summary
- Log absolute paths and warn when ECharts resources are missing during setup
- Highlight missing chart resources in the Chart panel with red text
- Document required locations for `resources/chart.html` and `third_party/echarts/echarts.min.js`

## Testing
- ✅ `cmake -B build -S .`
- ✅ `cmake --build build`
- ✅ `cd build && ctest`
- ⚠️ `./build/TradingTerminal` *(executable not built: missing cpr dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ca2051a8832780bc744e316e617c