### PR TITLE
Convert open_time to ISO timestamps for charting

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -43,8 +43,9 @@
     window.receiveFromCpp = function(obj) {
       try {
         if (Array.isArray(obj.x) && Array.isArray(obj.y)) {
+          const formatted = obj.x.map(s => new Date(s).toLocaleString());
           chart.setOption({
-            xAxis: { data: obj.x },
+            xAxis: { data: formatted },
             series: [{
               name: 'Candlestick',
               type: 'candlestick',

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -2,6 +2,8 @@
 
 #include <fstream>
 #include <iomanip>
+#include <sstream>
+#include <ctime>
 #include <cstdlib>
 #include <charconv>
 #include <string_view>
@@ -370,7 +372,14 @@ nlohmann::json CandleManager::load_candles_json(const std::string& symbol,
     nlohmann::json x = nlohmann::json::array();
     nlohmann::json y = nlohmann::json::array();
     for (const auto& c : candles) {
-        x.push_back(c.open_time);
+        long long ms = c.open_time;
+        std::time_t sec = ms / 1000;
+        int millis = static_cast<int>(ms % 1000);
+        std::tm tm = *std::gmtime(&sec);
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%FT%T") << '.'
+            << std::setw(3) << std::setfill('0') << millis << 'Z';
+        x.push_back(oss.str());
         y.push_back({c.open, c.close, c.low, c.high});
     }
     return nlohmann::json{{"x", std::move(x)}, {"y", std::move(y)}};

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -87,7 +87,7 @@ TEST(CandleManagerTest, LoadCandlesJsonReturnsOHLC) {
 
     auto json = cm.load_candles_json("TEST","1m");
     nlohmann::json expected = {
-        {"x", {0, 60000}},
+        {"x", {"1970-01-01T00:00:00.000Z", "1970-01-01T00:01:00.000Z"}},
         {"y", {
             {10.0, 15.0, 5.0, 20.0},
             {12.0, 18.0, 8.0, 22.0}


### PR DESCRIPTION
## Summary
- Serialize candle open times as ISO-8601 strings in `load_candles_json`
- Parse and format date strings on the chart's x-axis for human readable labels
- Adjust unit test to expect ISO formatted timestamps

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure`
- `node - <<'NODE'
const x = ["1970-01-01T00:00:00.000Z", "1970-01-01T00:01:00.000Z"];
const formatted = x.map(s => new Date(s).toLocaleString());
console.log(formatted.join(', '));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a4ccbbed9c83279a1ce4293fc3cd85