### PR TITLE
Validate webview handle result before storing

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -3,13 +3,19 @@
 #include <filesystem>
 #include <utility>
 
+#include "core/logger.h"
+
 EChartsWindow::EChartsWindow(const std::string &html_path, bool debug)
     : html_path_(html_path), debug_(debug),
       view_(std::make_unique<webview::webview>(debug, nullptr)) {}
 
-void EChartsWindow::SetHandler(JsonHandler handler) { handler_ = std::move(handler); }
+void EChartsWindow::SetHandler(JsonHandler handler) {
+  handler_ = std::move(handler);
+}
 
-void EChartsWindow::SetInitData(nlohmann::json data) { init_data_ = std::move(data); }
+void EChartsWindow::SetInitData(nlohmann::json data) {
+  init_data_ = std::move(data);
+}
 
 void EChartsWindow::Show() {
   if (!view_) {
@@ -18,7 +24,14 @@ void EChartsWindow::Show() {
 
   view_->set_title("ECharts");
   view_->set_size(800, 600, WEBVIEW_HINT_NONE);
-  native_handle_ = view_->window();
+  auto handle_result = view_->window();
+  if (handle_result.ok()) {
+    native_handle_.store(handle_result.value());
+  } else {
+    Core::Logger::instance().error(
+        std::string("Failed to get native window handle: ") +
+        handle_result.error().message());
+  }
 
   view_->bind("bridge", [this](std::string req) -> std::string {
     nlohmann::json json;
@@ -49,7 +62,8 @@ void EChartsWindow::Show() {
 
 void EChartsWindow::SendToJs(const nlohmann::json &data) {
   if (view_) {
-    std::string script = std::string("window.receiveFromCpp(") + data.dump() + ");";
+    std::string script =
+        std::string("window.receiveFromCpp(") + data.dump() + ");";
     view_->eval(script);
   }
 }
@@ -61,13 +75,10 @@ void EChartsWindow::Close() {
   }
 }
 
-void *EChartsWindow::GetNativeHandle() const {
-  return native_handle_.load();
-}
+void *EChartsWindow::GetNativeHandle() const { return native_handle_.load(); }
 
 void EChartsWindow::SetSize(int width, int height) {
   if (view_) {
     view_->set_size(width, height, WEBVIEW_HINT_NONE);
   }
 }
-


### PR DESCRIPTION
## Summary
- guard window handle extraction with error logging
- include logger for diagnostics in ECharts window

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a4dfae00348327bcdf7d37e07144bf