### PR TITLE
Expose config path resolver and use it across components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/app.cpp
     src/config_manager.cpp
     src/config_schema.cpp
+    src/config_path.cpp
       src/candle.cpp
       src/signal.cpp
       src/core/candle_manager.cpp
@@ -123,6 +124,7 @@ add_executable(test_candle_manager
   src/core/interval_utils.cpp
   src/candle.cpp
   src/core/logger.cpp
+  src/config_path.cpp
 )
 target_include_directories(test_candle_manager PRIVATE src include)
 target_link_libraries(test_candle_manager PRIVATE GTest::gtest_main)
@@ -136,6 +138,7 @@ add_executable(test_signal
   src/config_manager.cpp
   src/config_schema.cpp
   src/core/logger.cpp
+  src/config_path.cpp
 )
 target_include_directories(test_signal PRIVATE src include)
 target_link_libraries(test_signal PRIVATE GTest::gtest_main)
@@ -178,6 +181,7 @@ add_executable(test_kline_stream
   src/core/interval_utils.cpp
   src/candle.cpp
   src/core/logger.cpp
+  src/config_path.cpp
 )
 target_include_directories(test_kline_stream PRIVATE src include)
 target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,6 +1,7 @@
 #include "app.h"
 
 #include "config_manager.h"
+#include "config_path.h"
 #include "core/backtester.h"
 #include "core/candle.h"
 #include "core/candle_manager.h"
@@ -47,7 +48,7 @@ void App::add_status(const std::string &msg) {
 }
 
 bool App::init_window() {
-  auto cfg = Config::ConfigManager::load("config.json");
+  auto cfg = Config::ConfigManager::load(resolve_config_path().string());
   auto level = cfg ? cfg->log_level : Core::LogLevel::Info;
   Core::Logger::instance().set_min_level(level);
   bool console = cfg ? cfg->log_to_console : true;
@@ -82,7 +83,7 @@ void App::setup_imgui() {
 }
 
 void App::load_config() {
-  auto cfg = Config::ConfigManager::load("config.json");
+  auto cfg = Config::ConfigManager::load(resolve_config_path().string());
   std::vector<std::string> pair_names;
   if (cfg) {
     pair_names = cfg->pairs;
@@ -133,7 +134,7 @@ void App::load_config() {
     std::vector<std::string> names;
     for (const auto &p : this->ctx_->pairs)
       names.push_back(p.name);
-    Config::ConfigManager::save_selected_pairs("config.json", names);
+    Config::ConfigManager::save_selected_pairs(resolve_config_path().string(), names);
   };
   this->ctx_->selected_pairs = pair_names;
   this->ctx_->active_pair = this->ctx_->selected_pairs[0];

--- a/src/config_path.cpp
+++ b/src/config_path.cpp
@@ -1,0 +1,59 @@
+#include "config_path.h"
+
+#include <array>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#elif __APPLE__
+#include <mach-o/dyld.h>
+#else
+#include <limits.h>
+#include <unistd.h>
+#endif
+
+namespace {
+std::filesystem::path executable_dir() {
+#ifdef _WIN32
+    wchar_t buffer[MAX_PATH];
+    DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    return std::filesystem::path(buffer, buffer + len).parent_path();
+#elif __APPLE__
+    char path[1024];
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) == 0)
+        return std::filesystem::path(path).parent_path();
+    return std::filesystem::current_path();
+#else
+    char result[PATH_MAX];
+    ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
+    if (count != -1)
+        return std::filesystem::path(std::string(result, count)).parent_path();
+    return std::filesystem::current_path();
+#endif
+}
+} // namespace
+
+std::filesystem::path resolve_config_path(const std::filesystem::path &filename) {
+    if (filename.is_absolute()) {
+        return filename;
+    }
+    if (filename.filename() != "config.json") {
+        return std::filesystem::absolute(filename);
+    }
+    if (const char *env_cfg = std::getenv("CANDLE_CONFIG_PATH")) {
+        return std::filesystem::path(env_cfg);
+    }
+    auto exe_dir = executable_dir();
+    std::array<std::filesystem::path, 3> candidates = {
+        exe_dir / filename,
+        exe_dir.parent_path() / filename,
+        std::filesystem::current_path() / filename,
+    };
+    for (const auto &c : candidates) {
+        if (std::filesystem::exists(c))
+            return c;
+    }
+    return candidates[0];
+}
+

--- a/src/config_path.h
+++ b/src/config_path.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <filesystem>
+
+// Resolves the path to the configuration file. If the provided filename is an
+// absolute path or differs from the default "config.json", it is returned as
+// is (converted to an absolute path if necessary). Otherwise, the function
+// searches common locations and respects the CANDLE_CONFIG_PATH environment
+// variable.
+std::filesystem::path resolve_config_path(const std::filesystem::path &filename = "config.json");
+

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -7,59 +7,14 @@
 #include <cstdlib>
 #include <charconv>
 #include <string_view>
-#include <array>
 #include <nlohmann/json.hpp>
 #include "core/logger.h"
 #include "interval_utils.h"
-
-#ifdef _WIN32
-#include <windows.h>
-#elif __APPLE__
-#include <mach-o/dyld.h>
-#else
-#include <unistd.h>
-#include <limits.h>
-#endif
+#include "config_path.h"
 
 namespace Core {
 
 namespace {
-
-std::filesystem::path executable_dir() {
-#ifdef _WIN32
-    wchar_t buffer[MAX_PATH];
-    DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
-    return std::filesystem::path(buffer, buffer + len).parent_path();
-#elif __APPLE__
-    char path[1024];
-    uint32_t size = sizeof(path);
-    if (_NSGetExecutablePath(path, &size) == 0)
-        return std::filesystem::path(path).parent_path();
-    return std::filesystem::current_path();
-#else
-    char result[PATH_MAX];
-    ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
-    if (count != -1)
-        return std::filesystem::path(std::string(result, count)).parent_path();
-    return std::filesystem::current_path();
-#endif
-}
-
-std::filesystem::path resolve_config_path() {
-    if (const char* env_cfg = std::getenv("CANDLE_CONFIG_PATH")) {
-        return std::filesystem::path(env_cfg);
-    }
-    auto exe_dir = executable_dir();
-    std::array<std::filesystem::path,3> candidates = {
-        exe_dir / "config.json",
-        exe_dir.parent_path() / "config.json",
-        std::filesystem::current_path() / "config.json"
-    };
-    for (const auto& c : candidates) {
-        if (std::filesystem::exists(c)) return c;
-    }
-    return candidates[0];
-}
 
 std::filesystem::path resolve_data_dir() {
     if (const char* env_dir = std::getenv("CANDLE_DATA_DIR")) {

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -5,6 +5,7 @@
 #include "core/logger.h"
 #include "core/candle_utils.h"
 #include "config_manager.h"
+#include "config_path.h"
 
 #include <algorithm>
 #include <nlohmann/json.hpp>
@@ -56,7 +57,7 @@ Core::KlinesResult DataService::fetch_klines(
 Core::KlinesResult DataService::fetch_klines_alt(
     const std::string &symbol, const std::string &interval, int limit,
     int max_retries, std::chrono::milliseconds retry_delay) const {
-  auto cfg = Config::ConfigManager::load("config.json");
+  auto cfg = Config::ConfigManager::load(resolve_config_path().string());
   std::string fallback = cfg ? cfg->fallback_provider : "";
   std::chrono::milliseconds current_delay = retry_delay;
   Core::KlinesResult res;
@@ -271,7 +272,7 @@ bool DataService::remove_candles(const std::string &pair) const {
 
 bool DataService::reload_candles(const std::string &pair, const std::string &interval) const {
   candle_manager_.clear_interval(pair, interval);
-  auto cfg = Config::ConfigManager::load("config.json");
+  auto cfg = Config::ConfigManager::load(resolve_config_path().string());
   int limit = cfg ? static_cast<int>(cfg->candles_limit) : 1000;
   auto res = fetch_klines(pair, interval, limit);
   if (res.error == Core::FetchError::None && !res.candles.empty()) {

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -2,6 +2,7 @@
 #include "app.h"
 
 #include "config_manager.h"
+#include "config_path.h"
 #include "core/data_fetcher.h"
 #include "core/interval_utils.h"
 #include "imgui.h"
@@ -16,7 +17,7 @@ using namespace Core;
 
 namespace {
 const size_t EXPECTED_CANDLES = [] {
-  auto cfg = Config::ConfigManager::load("config.json");
+  auto cfg = Config::ConfigManager::load(resolve_config_path().string());
   return cfg ? cfg->candles_limit : 5000u;
 }();
 constexpr size_t THRESHOLD_LOW = 100;
@@ -220,7 +221,7 @@ bool RenderPairRow(
     selected_pairs.erase(std::remove(selected_pairs.begin(), selected_pairs.end(),
                                      item.name),
                          selected_pairs.end());
-    Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
+    Config::ConfigManager::save_selected_pairs(resolve_config_path().string(), selected_pairs);
     data_service.remove_candles(item.name);
     if (cancel_pair)
       cancel_pair(item.name);
@@ -302,7 +303,7 @@ static void RenderLoadControls(
       if (std::find(selected_pairs.begin(), selected_pairs.end(), symbol) ==
           selected_pairs.end()) {
         selected_pairs.push_back(symbol);
-        Config::ConfigManager::save_selected_pairs("config.json", selected_pairs);
+        Config::ConfigManager::save_selected_pairs(resolve_config_path().string(), selected_pairs);
       }
       if (!LoadInitialCandles(data_service, symbol, intervals, all_candles,
                               load_error)) {


### PR DESCRIPTION
## Summary
- centralize configuration path resolution in new `config_path` utility
- ensure `ConfigManager::load` and `save_selected_pairs` resolve config file paths
- update application, services, and UI to load and save config via resolved paths

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a4e36260c4832788447bbb945432c7