### PR TITLE
Load assets relative to executable directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/kline_stream.cpp
     src/core/iwebsocket.cpp
     src/core/logger.cpp
+    src/core/path_utils.cpp
     src/journal.cpp
     src/services/data_service.cpp
     src/services/journal_service.cpp

--- a/src/core/path_utils.cpp
+++ b/src/core/path_utils.cpp
@@ -1,0 +1,39 @@
+#include "core/path_utils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#elif __APPLE__
+#include <mach-o/dyld.h>
+#else
+#include <limits.h>
+#include <unistd.h>
+#endif
+
+namespace Core {
+
+std::filesystem::path executable_dir() {
+#ifdef _WIN32
+    wchar_t buffer[MAX_PATH];
+    DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    return std::filesystem::path(buffer, buffer + len).parent_path();
+#elif __APPLE__
+    char path[1024];
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) == 0)
+        return std::filesystem::path(path).parent_path();
+    return std::filesystem::current_path();
+#else
+    char result[PATH_MAX];
+    ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
+    if (count != -1)
+        return std::filesystem::path(std::string(result, count)).parent_path();
+    return std::filesystem::current_path();
+#endif
+}
+
+std::filesystem::path path_from_executable(const std::filesystem::path &relative) {
+    return executable_dir() / relative;
+}
+
+} // namespace Core
+

--- a/src/core/path_utils.h
+++ b/src/core/path_utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <filesystem>
+
+namespace Core {
+
+// Returns the directory containing the current executable.
+std::filesystem::path executable_dir();
+
+// Resolves a path relative to the executable directory.
+std::filesystem::path path_from_executable(const std::filesystem::path &relative);
+
+} // namespace Core
+


### PR DESCRIPTION
## Summary
- add `Core::path_from_executable` helper to resolve paths relative to the running binary
- use helper in `UiManager` to locate chart HTML and ECharts script
- warn with expected directory layout when resources are missing

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7e98364832795a532f9affc3aec