### PR TITLE
Use shared data directory for journal files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/data_fetcher.cpp
     src/core/interval_utils.cpp
     src/core/candle_utils.cpp
+    src/core/data_dir.cpp
     src/core/net/token_bucket_rate_limiter.cpp
     src/core/net/cpr_http_client.cpp
     src/core/backtester.cpp
@@ -122,6 +123,7 @@ add_test(NAME test_backtester COMMAND test_backtester)
 add_executable(test_candle_manager
   tests/test_candle_manager.cpp
   src/core/candle_manager.cpp
+  src/core/data_dir.cpp
   src/core/interval_utils.cpp
   src/candle.cpp
   src/core/logger.cpp
@@ -179,6 +181,7 @@ add_executable(test_kline_stream
   src/core/kline_stream.cpp
   src/core/iwebsocket.cpp
   src/core/candle_manager.cpp
+  src/core/data_dir.cpp
   src/core/interval_utils.cpp
   src/candle.cpp
   src/core/logger.cpp

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -478,7 +478,7 @@ void App::render_ui() {
                       this->ctx_->active_pair, this->ctx_->selected_interval, status_);
 
     DrawAnalyticsWindow(this->ctx_->all_candles, this->ctx_->active_pair, this->ctx_->selected_interval);
-    DrawJournalWindow(journal_service_.journal());
+    DrawJournalWindow(journal_service_);
   }
 
   ui_manager_.draw_echarts_panel(this->ctx_->selected_interval);

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -4,62 +4,15 @@
 #include <iomanip>
 #include <sstream>
 #include <ctime>
-#include <cstdlib>
 #include <charconv>
 #include <string_view>
-#include <nlohmann/json.hpp>
 #include "core/logger.h"
 #include "interval_utils.h"
-#include "config_path.h"
+#include "core/data_dir.h"
 
 namespace Core {
 
 namespace {
-
-std::filesystem::path resolve_data_dir() {
-    if (const char* env_dir = std::getenv("CANDLE_DATA_DIR")) {
-        std::filesystem::path dir(env_dir);
-        std::filesystem::create_directories(dir);
-        return dir;
-    }
-
-    auto cfg_path = resolve_config_path();
-    nlohmann::json j;
-    std::filesystem::path dir;
-
-    if (std::ifstream cfg(cfg_path); cfg.is_open()) {
-        try {
-            cfg >> j;
-            if (j.contains("data_dir") && j["data_dir"].is_string()) {
-                dir = j["data_dir"].get<std::string>();
-            }
-        } catch (const std::exception& e) {
-            Logger::instance().error("Failed to parse " + cfg_path.string() + ": " + e.what());
-        }
-    }
-
-    if (dir.empty()) {
-        const char* home = nullptr;
-#ifdef _WIN32
-        home = std::getenv("USERPROFILE");
-#else
-        home = std::getenv("HOME");
-#endif
-        if (home) {
-            dir = std::filesystem::path(home) / "candle_data";
-        } else {
-            dir = std::filesystem::current_path() / "candle_data";
-        }
-        j["data_dir"] = dir.string();
-        std::ofstream out(cfg_path);
-        if (out.is_open()) {
-            out << j.dump(4);
-        }
-    }
-
-    std::filesystem::create_directories(dir);
-    return dir;
-}
 
 void fill_missing(std::vector<Candle> &candles, long long interval_ms) {
     if (candles.size() < 2 || interval_ms <= 0) return;

--- a/src/core/data_dir.cpp
+++ b/src/core/data_dir.cpp
@@ -1,0 +1,58 @@
+#include "core/data_dir.h"
+#include "config_path.h"
+#include "core/logger.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+namespace Core {
+
+std::filesystem::path resolve_data_dir() {
+    if (const char* env_dir = std::getenv("CANDLE_DATA_DIR")) {
+        std::filesystem::path dir(env_dir);
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+
+    auto cfg_path = resolve_config_path();
+    nlohmann::json j;
+    std::filesystem::path dir;
+
+    if (std::ifstream cfg(cfg_path); cfg.is_open()) {
+        try {
+            cfg >> j;
+            if (j.contains("data_dir") && j["data_dir"].is_string()) {
+                dir = j["data_dir"].get<std::string>();
+            }
+        } catch (const std::exception& e) {
+            Logger::instance().error("Failed to parse " + cfg_path.string() + ": " + e.what());
+        }
+    }
+
+    if (dir.empty()) {
+        const char* home = nullptr;
+#ifdef _WIN32
+        home = std::getenv("USERPROFILE");
+#else
+        home = std::getenv("HOME");
+#endif
+        if (home) {
+            dir = std::filesystem::path(home) / "candle_data";
+        } else {
+            dir = std::filesystem::current_path() / "candle_data";
+        }
+        j["data_dir"] = dir.string();
+        std::ofstream out(cfg_path);
+        if (out.is_open()) {
+            out << j.dump(4);
+        }
+    }
+
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+} // namespace Core
+

--- a/src/core/data_dir.h
+++ b/src/core/data_dir.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <filesystem>
+
+namespace Core {
+std::filesystem::path resolve_data_dir();
+}
+

--- a/src/services/journal_service.cpp
+++ b/src/services/journal_service.cpp
@@ -1,10 +1,21 @@
 #include "services/journal_service.h"
+#include <filesystem>
+
+JournalService::JournalService(const std::filesystem::path &base_dir)
+    : m_base_dir(base_dir) {
+  std::filesystem::create_directories(m_base_dir);
+}
 
 bool JournalService::load(const std::string &filename) {
-  return m_journal.load_json(filename);
+  return m_journal.load_json((m_base_dir / filename).string());
 }
 
 bool JournalService::save(const std::string &filename) const {
-  return m_journal.save_json(filename);
+  return m_journal.save_json((m_base_dir / filename).string());
+}
+
+void JournalService::set_base_dir(const std::filesystem::path &dir) {
+  m_base_dir = dir;
+  std::filesystem::create_directories(m_base_dir);
 }
 

--- a/src/services/journal_service.h
+++ b/src/services/journal_service.h
@@ -1,20 +1,28 @@
 #pragma once
 
 #include <string>
+#include <filesystem>
 
 #include "journal.h"
+#include "core/data_dir.h"
 
 // Simple wrapper around the Journal class.  Abstracting it into a
 // service allows the application to interact with journal data without
 // being tied to a concrete storage implementation.
 class JournalService {
 public:
+  explicit JournalService(const std::filesystem::path &base_dir = Core::resolve_data_dir());
+
   bool load(const std::string &filename);
   bool save(const std::string &filename) const;
+
+  void set_base_dir(const std::filesystem::path &dir);
+  const std::filesystem::path &base_dir() const { return m_base_dir; }
 
   Journal::Journal &journal() { return m_journal; }
 
 private:
   Journal::Journal m_journal;
+  std::filesystem::path m_base_dir;
 };
 

--- a/src/ui/journal_window.cpp
+++ b/src/ui/journal_window.cpp
@@ -8,7 +8,8 @@
 #include <ctime>
 #include <cstring>
 
-void DrawJournalWindow(Journal::Journal& journal) {
+void DrawJournalWindow(JournalService &service) {
+    auto &journal = service.journal();
     ImGui::Begin("Journal");
     static char j_symbol[32] = "";
     static int j_side = 0;
@@ -33,8 +34,8 @@ void DrawJournalWindow(Journal::Journal& journal) {
     }
     ImGui::SameLine();
     if (ImGui::Button("Save")) {
-        journal.save_json("journal.json");
-        journal.save_csv("journal.csv");
+        service.save("journal.json");
+        journal.save_csv((service.base_dir() / "journal.csv").string());
     }
 
     static int edit_index = -1;

--- a/src/ui/journal_window.h
+++ b/src/ui/journal_window.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "journal.h"
+#include "services/journal_service.h"
 
-void DrawJournalWindow(Journal::Journal& journal);
+void DrawJournalWindow(JournalService &service);
 


### PR DESCRIPTION
## Summary
- expose Core::resolve_data_dir
- allow JournalService to use base directory
- save journal data relative to this dir

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ea82c2cc8327850b2228401ec8fc