### PR TITLE
Improve Gate.io alt data fetching and add tests

### DIFF
--- a/tests/test_data_fetcher.cpp
+++ b/tests/test_data_fetcher.cpp
@@ -1,6 +1,7 @@
 #include "core/data_fetcher.h"
 #include <gtest/gtest.h>
 #include <memory>
+#include <nlohmann/json.hpp>
 
 using namespace Core;
 
@@ -12,13 +13,24 @@ public:
 class FakeHttpClient : public IHttpClient {
 public:
   std::vector<HttpResponse> responses;
+  std::vector<std::string> urls;
   size_t index{0};
   HttpResponse get(const std::string &url) override {
+    urls.push_back(url);
     if (index < responses.size())
       return responses[index++];
     return {};
   }
 };
+
+static std::string make_gate_response(int start_ts, int count, int interval) {
+  nlohmann::json arr = nlohmann::json::array();
+  for (int i = 0; i < count; ++i) {
+    int ts = start_ts + i * interval;
+    arr.push_back({std::to_string(ts), "1", "2", "3", "4", "5"});
+  }
+  return arr.dump();
+}
 
 TEST(DataFetcherTest, FetchKlinesParsesCandles) {
   auto http = std::make_shared<FakeHttpClient>();
@@ -41,6 +53,8 @@ TEST(DataFetcherTest, AltApiParsesCandles) {
   auto res = fetcher.fetch_klines_alt("BTCUSDT", "5s", 1);
   EXPECT_EQ(res.error, FetchError::None);
   ASSERT_EQ(res.candles.size(), 1u);
+  EXPECT_EQ(res.candles[0].close_time - res.candles[0].open_time + 1,
+            10000);
 }
 
 TEST(DataFetcherTest, AsyncDelegatesToSync) {
@@ -54,5 +68,25 @@ TEST(DataFetcherTest, AsyncDelegatesToSync) {
   auto res = fut.get();
   EXPECT_EQ(res.error, FetchError::None);
   ASSERT_EQ(res.candles.size(), 1u);
+}
+
+TEST(DataFetcherTest, AltApiBatchesRequestsOverLimit) {
+  auto http = std::make_shared<FakeHttpClient>();
+  http->responses.push_back({200, make_gate_response(10000, 1000, 10), "", false});
+  http->responses.push_back({200, make_gate_response(5000, 500, 10), "", false});
+  auto limiter = std::make_shared<DummyLimiter>();
+  DataFetcher fetcher(http, limiter);
+  auto res = fetcher.fetch_klines_alt("BTCUSDT", "5s", 1500);
+  EXPECT_EQ(res.error, FetchError::None);
+  EXPECT_EQ(res.candles.size(), 1500u);
+  EXPECT_EQ(http->urls.size(), 2u);
+}
+
+TEST(DataFetcherTest, AltApiRejectsUnsupportedInterval) {
+  auto http = std::make_shared<FakeHttpClient>();
+  auto limiter = std::make_shared<DummyLimiter>();
+  DataFetcher fetcher(http, limiter);
+  auto res = fetcher.fetch_klines_alt("BTCUSDT", "7s", 1);
+  EXPECT_EQ(res.error, FetchError::HttpError);
 }
 


### PR DESCRIPTION
## Summary
- Map unsupported intervals to Gate.io equivalents and validate them
- Batch Gate.io requests when limit exceeds 1000 and clamp the limit per request
- Add tests for batching, interval mapping, and invalid interval handling

## Testing
- `./build/test_data_fetcher`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecb052bc832799cefe3c9b11f5ae