### PR TITLE
Copy resources automatically for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Standalone C++ trading terminal using ImGui with an embedded chart powered by [A
    ```
    cp -r resources third_party/echarts build/
    ```
-   После копирования убедитесь, что файлы `resources/chart.html` и
-   `third_party/echarts/echarts.min.js` находятся рядом с исполняемым
+   При сборке в Windows скрипт `build_and_run.bat` автоматически копирует `resources/chart.html` и
+   `third_party/echarts/echarts.min.js` в каталоги `Debug` и `Release`, поэтому ручное копирование не требуется.
+   После копирования (или автоматического переноса) убедитесь, что файлы находятся рядом с исполняемым
    файлом, например:
 
    ```

--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -24,6 +24,15 @@ if %errorlevel% neq 0 (
     goto :eof
 )
 
+echo Copying resources...
+for %%c in (Debug Release) do (
+    if exist "%%c" (
+        echo Copying resources to %%c...
+        robocopy "%PROJECT_DIR%resources" "%%c\resources" "chart.html" >nul
+        robocopy "%PROJECT_DIR%third_party\echarts" "%%c\third_party\echarts" "echarts.min.js" >nul
+    )
+)
+
 echo Running the application...
 pushd "%BUILD_DIR%"
 if exist "Debug\TradingTerminal.exe" (


### PR DESCRIPTION
## Summary
- Add post-build resource copy step in `build_and_run.bat` using `robocopy` for Debug/Release
- Document automatic resource copying in Windows builds in `README.md`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "unofficial-webview2" with any of the following names: unofficial-webview2Config.cmake, unofficial-webview2-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a56b6c3aac8327bfcc4ab13f8ca0cd