### PR TITLE
Handle missing journal file creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,15 @@ target_include_directories(test_kline_stream PRIVATE src include)
 target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)
 add_test(NAME test_kline_stream COMMAND test_kline_stream)
 
+add_executable(test_journal
+  tests/test_journal.cpp
+  src/journal.cpp
+  src/core/logger.cpp
+)
+target_include_directories(test_journal PRIVATE src include)
+target_link_libraries(test_journal PRIVATE GTest::gtest_main)
+add_test(NAME test_journal COMMAND test_journal)
+
   add_executable(test_logger
     tests/test_logger.cpp
     src/core/logger.cpp
@@ -202,6 +211,6 @@ add_test(NAME test_kline_stream COMMAND test_kline_stream)
   # test_echarts_serialization temporarily disabled due to build issues
 
   add_custom_target(ctest COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-      DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_kline_stream test_data_fetcher test_interval_utils test_logger
+      DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_kline_stream test_data_fetcher test_interval_utils test_logger test_journal
     )
 

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -12,8 +12,9 @@ namespace Journal {
 bool Journal::load_json(const std::string &filename) {
   std::ifstream f(filename);
   if (!f.is_open()) {
-    Core::Logger::instance().error("Failed to open journal file: " + filename);
-    return false;
+    m_entries.clear();
+    save_json(filename);
+    return true;
   }
 
   std::stringstream buffer;

--- a/tests/test_journal.cpp
+++ b/tests/test_journal.cpp
@@ -1,6 +1,9 @@
-#include <gtest/gtest.h>
 #include "journal.h"
+#include "core/logger.h"
+#include <gtest/gtest.h>
 #include <filesystem>
+#include <fstream>
+#include <thread>
 
 TEST(JournalTest, Serialization) {
     ASSERT_EQ(Journal::side_to_string(Journal::Side::Buy), "BUY");
@@ -36,5 +39,39 @@ TEST(JournalTest, Serialization) {
     EXPECT_EQ(j3.entries()[1].side, Journal::Side::Sell);
 
     std::filesystem::remove_all(dir);
+}
+
+TEST(JournalTest, LoadMissingFileCreatesFileWithoutError) {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::temp_directory_path() / "journal_missing";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    auto json_file = (dir / "journal.json").string();
+    auto log_file = (dir / "log.txt").string();
+
+    Core::Logger::instance().set_file(log_file);
+    Core::Logger::instance().enable_console_output(false);
+    Core::Logger::instance().set_min_level(Core::LogLevel::Error);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    Journal::Journal j;
+    bool loaded = j.load_json(json_file);
+    EXPECT_TRUE(loaded);
+    EXPECT_TRUE(fs::exists(json_file));
+
+    std::ifstream in(json_file);
+    std::string content;
+    std::getline(in, content);
+    EXPECT_EQ(content, "[]");
+    in.close();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::ifstream log_in(log_file);
+    bool empty = (log_in.peek() == std::ifstream::traits_type::eof());
+    EXPECT_TRUE(empty);
+    log_in.close();
+
+    Core::Logger::instance().set_file("");
+    fs::remove_all(dir);
 }
 


### PR DESCRIPTION
## Summary
- Create an empty journal JSON file when load_json can't open the target
- Add regression test confirming file creation and absence of error logs
- Wire journal test into build system

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a56d5c44388327a6fdeea9aa6c90a0