### PR TITLE
Handle missing and empty journal files gracefully

### DIFF
--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -21,8 +21,9 @@ bool Journal::load_json(const std::string &filename) {
   buffer << f.rdbuf();
   std::string content = buffer.str();
   if (content.empty()) {
-    Core::Logger::instance().error("Journal file is empty: " + filename);
-    return false;
+    m_entries.clear();
+    save_json(filename);
+    return true;
   }
   if (!nlohmann::json::accept(content)) {
     Core::Logger::instance().error("Invalid JSON format in journal file: " +

--- a/src/services/journal_service.cpp
+++ b/src/services/journal_service.cpp
@@ -7,7 +7,12 @@ JournalService::JournalService(const std::filesystem::path &base_dir)
 }
 
 bool JournalService::load(const std::string &filename) {
-  return m_journal.load_json((m_base_dir / filename).string());
+  auto path = m_base_dir / filename;
+  if (!std::filesystem::exists(path)) {
+    save(filename);
+    return true;
+  }
+  return m_journal.load_json(path.string());
 }
 
 bool JournalService::save(const std::string &filename) const {
@@ -18,4 +23,3 @@ void JournalService::set_base_dir(const std::filesystem::path &dir) {
   m_base_dir = dir;
   std::filesystem::create_directories(m_base_dir);
 }
-

--- a/tests/test_journal.cpp
+++ b/tests/test_journal.cpp
@@ -1,77 +1,114 @@
-#include "journal.h"
 #include "core/logger.h"
-#include <gtest/gtest.h>
+#include "journal.h"
 #include <filesystem>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <thread>
 
 TEST(JournalTest, Serialization) {
-    ASSERT_EQ(Journal::side_to_string(Journal::Side::Buy), "BUY");
-    EXPECT_EQ(Journal::side_from_string("SELL"), Journal::Side::Sell);
+  ASSERT_EQ(Journal::side_to_string(Journal::Side::Buy), "BUY");
+  EXPECT_EQ(Journal::side_from_string("SELL"), Journal::Side::Sell);
 
-    Journal::Journal j;
-    Journal::Entry e1{"BTC", Journal::Side::Buy, 100.0, 1.5, 1000};
-    Journal::Entry e2{"ETH", Journal::Side::Sell, 200.0, 2.0, 2000};
-    j.add_entry(e1);
-    j.add_entry(e2);
+  Journal::Journal j;
+  Journal::Entry e1{"BTC", Journal::Side::Buy, 100.0, 1.5, 1000};
+  Journal::Entry e2{"ETH", Journal::Side::Sell, 200.0, 2.0, 2000};
+  j.add_entry(e1);
+  j.add_entry(e2);
 
-    std::filesystem::path dir = std::filesystem::temp_directory_path() / "journal_test";
-    std::filesystem::create_directories(dir);
-    auto json_file = (dir / "journal.json").string();
-    auto csv_file = (dir / "journal.csv").string();
-    bool saved_json = j.save_json(json_file);
-    bool saved_csv = j.save_csv(csv_file);
-    ASSERT_TRUE(saved_json && saved_csv);
+  std::filesystem::path dir =
+      std::filesystem::temp_directory_path() / "journal_test";
+  std::filesystem::create_directories(dir);
+  auto json_file = (dir / "journal.json").string();
+  auto csv_file = (dir / "journal.csv").string();
+  bool saved_json = j.save_json(json_file);
+  bool saved_csv = j.save_csv(csv_file);
+  ASSERT_TRUE(saved_json && saved_csv);
 
-    Journal::Journal j2;
-    bool loaded_json = j2.load_json(json_file);
-    ASSERT_TRUE(loaded_json);
-    ASSERT_EQ(j2.entries().size(), 2);
-    EXPECT_EQ(j2.entries()[0].symbol, "BTC");
-    EXPECT_EQ(j2.entries()[0].side, Journal::Side::Buy);
-    EXPECT_EQ(j2.entries()[1].side, Journal::Side::Sell);
+  Journal::Journal j2;
+  bool loaded_json = j2.load_json(json_file);
+  ASSERT_TRUE(loaded_json);
+  ASSERT_EQ(j2.entries().size(), 2);
+  EXPECT_EQ(j2.entries()[0].symbol, "BTC");
+  EXPECT_EQ(j2.entries()[0].side, Journal::Side::Buy);
+  EXPECT_EQ(j2.entries()[1].side, Journal::Side::Sell);
 
-    Journal::Journal j3;
-    bool loaded_csv = j3.load_csv(csv_file);
-    ASSERT_TRUE(loaded_csv);
-    ASSERT_EQ(j3.entries().size(), 2);
-    EXPECT_EQ(j3.entries()[0].side, Journal::Side::Buy);
-    EXPECT_EQ(j3.entries()[1].side, Journal::Side::Sell);
+  Journal::Journal j3;
+  bool loaded_csv = j3.load_csv(csv_file);
+  ASSERT_TRUE(loaded_csv);
+  ASSERT_EQ(j3.entries().size(), 2);
+  EXPECT_EQ(j3.entries()[0].side, Journal::Side::Buy);
+  EXPECT_EQ(j3.entries()[1].side, Journal::Side::Sell);
 
-    std::filesystem::remove_all(dir);
+  std::filesystem::remove_all(dir);
 }
 
 TEST(JournalTest, LoadMissingFileCreatesFileWithoutError) {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::temp_directory_path() / "journal_missing";
-    fs::remove_all(dir);
-    fs::create_directories(dir);
-    auto json_file = (dir / "journal.json").string();
-    auto log_file = (dir / "log.txt").string();
+  namespace fs = std::filesystem;
+  fs::path dir = fs::temp_directory_path() / "journal_missing";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  auto json_file = (dir / "journal.json").string();
+  auto log_file = (dir / "log.txt").string();
 
-    Core::Logger::instance().set_file(log_file);
-    Core::Logger::instance().enable_console_output(false);
-    Core::Logger::instance().set_min_level(Core::LogLevel::Error);
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  Core::Logger::instance().set_file(log_file);
+  Core::Logger::instance().enable_console_output(false);
+  Core::Logger::instance().set_min_level(Core::LogLevel::Error);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    Journal::Journal j;
-    bool loaded = j.load_json(json_file);
-    EXPECT_TRUE(loaded);
-    EXPECT_TRUE(fs::exists(json_file));
+  Journal::Journal j;
+  bool loaded = j.load_json(json_file);
+  EXPECT_TRUE(loaded);
+  EXPECT_TRUE(fs::exists(json_file));
 
-    std::ifstream in(json_file);
-    std::string content;
-    std::getline(in, content);
-    EXPECT_EQ(content, "[]");
-    in.close();
+  std::ifstream in(json_file);
+  std::string content;
+  std::getline(in, content);
+  EXPECT_EQ(content, "[]");
+  in.close();
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    std::ifstream log_in(log_file);
-    bool empty = (log_in.peek() == std::ifstream::traits_type::eof());
-    EXPECT_TRUE(empty);
-    log_in.close();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::ifstream log_in(log_file);
+  bool empty = (log_in.peek() == std::ifstream::traits_type::eof());
+  EXPECT_TRUE(empty);
+  log_in.close();
 
-    Core::Logger::instance().set_file("");
-    fs::remove_all(dir);
+  Core::Logger::instance().set_file("");
+  fs::remove_all(dir);
 }
 
+TEST(JournalTest, LoadEmptyFileCreatesArrayWithoutError) {
+  namespace fs = std::filesystem;
+  fs::path dir = fs::temp_directory_path() / "journal_empty";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  auto json_file = (dir / "journal.json").string();
+  auto log_file = (dir / "log.txt").string();
+
+  std::ofstream out(json_file);
+  out.close();
+
+  Core::Logger::instance().set_file(log_file);
+  Core::Logger::instance().enable_console_output(false);
+  Core::Logger::instance().set_min_level(Core::LogLevel::Error);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  Journal::Journal j;
+  bool loaded = j.load_json(json_file);
+  EXPECT_TRUE(loaded);
+  EXPECT_TRUE(fs::exists(json_file));
+
+  std::ifstream in(json_file);
+  std::string content;
+  std::getline(in, content);
+  EXPECT_EQ(content, "[]");
+  in.close();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::ifstream log_in(log_file);
+  bool empty = (log_in.peek() == std::ifstream::traits_type::eof());
+  EXPECT_TRUE(empty);
+  log_in.close();
+
+  Core::Logger::instance().set_file("");
+  fs::remove_all(dir);
+}


### PR DESCRIPTION
## Summary
- Skip loading missing journal files by creating a new empty journal instead
- Avoid error logging for empty journal files and initialize them as empty
- Add regression test for loading empty journal files

## Testing
- `ctest --test-dir build -R test_journal --output-on-failure`
- `ctest --test-dir build -R test_logger --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a57640e0448327bc361c46fe887ae7