### PR TITLE
Handle missing or empty journal files

### DIFF
--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -20,7 +20,8 @@ bool Journal::load_json(const std::string &filename) {
   std::stringstream buffer;
   buffer << f.rdbuf();
   std::string content = buffer.str();
-  if (content.empty()) {
+  auto first_non_ws = content.find_first_not_of(" \t\n\r");
+  if (first_non_ws == std::string::npos) {
     m_entries.clear();
     save_json(filename);
     return true;


### PR DESCRIPTION
## Summary
- Ensure journal loading treats whitespace-only files as empty and initializes a new journal file

## Testing
- `cmake .. -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build . --target test_journal`
- `ctest -R test_journal --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a57844f1d08327b5c92508dace919b