### PR TITLE
Implement configurable retry logic with backoff for fetch tasks

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -43,7 +43,8 @@ private:
   void render_ui();
   void cleanup();
   void update_next_fetch_time(long long candidate);
-  void schedule_retry(long long now_ms, const std::string &msg = "");
+  void schedule_retry(long long now_ms, std::chrono::milliseconds delay,
+                      const std::string &msg = "");
   void start_fetch_thread();
   void stop_fetch_thread();
 

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -57,6 +57,7 @@ struct AppContext {
     std::string interval;
     std::future<Core::KlinesResult> future;
     std::chrono::steady_clock::time_point start;
+    int retries = 0;
   };
   std::deque<FetchTask> fetch_queue;
   std::mutex fetch_mutex;
@@ -69,6 +70,8 @@ struct AppContext {
   std::function<void(const std::string &)> cancel_pair;
   std::string last_active_pair;
   std::string last_active_interval;
-  const std::chrono::seconds fetch_backoff{5};
+  std::chrono::milliseconds retry_delay{5000};
+  int max_retries = 3;
+  bool exponential_backoff = true;
   const std::chrono::seconds request_timeout{10};
 };


### PR DESCRIPTION
## Summary
- track retries for each fetch task and cap attempts at a configurable limit
- add retry delay with optional exponential backoff and surface final errors
- expose configurable retry parameters in application context

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a57a30460483279329ea86a42892a4