### PR TITLE
Fix ImGui DockSpace API usage

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -474,7 +474,8 @@ void App::update_next_fetch_time(long long candidate) {
 void App::render_ui() {
   ui_manager_.begin_frame();
 
-  ImGuiID dockspace_id = ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
+  ImGuiViewport* viewport = ImGui::GetMainViewport();
+  ImGuiID dockspace_id = ImGui::DockSpaceOverViewport(viewport->ID, viewport);
   static bool dock_init = false;
   if (!dock_init) {
     dock_init = true;


### PR DESCRIPTION
## Summary
- adjust DockSpaceOverViewport call to pass viewport ID for newer ImGui

## Testing
- `cmake -S . -B build` (fails: Could not find a package configuration file provided by "unofficial-webview2")

------
https://chatgpt.com/codex/tasks/task_e_68a57dc255788327abc52aa3bad18d92