### PR TITLE
feat: add dynamic interval selector

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -9,15 +9,18 @@
   </style>
 </head>
 <body>
-  <select id="interval">
-    <option value="1m">1m</option>
-    <option value="5m">5m</option>
-    <option value="1h">1h</option>
-  </select>
+  <select id="interval"></select>
   <div id="chart" style="height:90%;"></div>
   <script>
     const chart = echarts.init(document.getElementById('chart'));
     const intervalSel = document.getElementById('interval');
+    const intervals = ['5s', '15s', '1m', '3m', '5m', '15m', '1h', '4h', '1d'];
+    intervals.forEach(iv => {
+      const opt = document.createElement('option');
+      opt.value = iv;
+      opt.textContent = iv;
+      intervalSel.appendChild(opt);
+    });
     intervalSel.addEventListener('change', function() {
       sendToCpp({ interval: intervalSel.value });
     });
@@ -54,6 +57,12 @@
           });
         }
         if (obj.interval) {
+          if (!intervals.includes(obj.interval)) {
+            const opt = document.createElement('option');
+            opt.value = obj.interval;
+            opt.textContent = obj.interval;
+            intervalSel.appendChild(opt);
+          }
           intervalSel.value = obj.interval;
         }
       } catch (e) {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -145,7 +145,9 @@ void App::load_config() {
                             ? exchange_pairs_res.symbols
                             : std::vector<std::string>{};
 
-  this->ctx_->selected_interval = this->ctx_->intervals.empty() ? "1m" : this->ctx_->intervals[0];
+  this->ctx_->selected_interval =
+      this->ctx_->intervals.empty() ? "1m" : this->ctx_->intervals[0];
+  ui_manager_.set_initial_interval(this->ctx_->selected_interval);
   journal_service_.load("journal.json");
 
   for (const auto &pair : this->ctx_->selected_pairs) {

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -56,6 +56,12 @@ bool UiManager::setup(GLFWwindow *window) {
           on_interval_changed_(req.at("interval").get<std::string>());
         }
       }
+      if (req.contains("request") && req.at("request") == "init") {
+        if (!current_interval_.empty()) {
+          echarts_window_->SendToJs(
+              nlohmann::json{{"interval", current_interval_}});
+        }
+      }
       return nlohmann::json{};
     });
     echarts_thread_ = std::thread([this]() { echarts_window_->Show(); });
@@ -110,6 +116,15 @@ void UiManager::draw_echarts_panel(const std::string &selected_interval) {
 void UiManager::set_interval_callback(
     std::function<void(const std::string &)> cb) {
   on_interval_changed_ = std::move(cb);
+}
+
+void UiManager::set_initial_interval(const std::string &interval) {
+  current_interval_ = interval;
+#if USE_WEBVIEW
+  if (echarts_window_) {
+    echarts_window_->SendToJs(nlohmann::json{{"interval", interval}});
+  }
+#endif
 }
 
 void UiManager::end_frame(GLFWwindow *window) {

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -22,6 +22,8 @@ public:
   // Set callback to be invoked when the JS side notifies about a new interval
   // selection.
   void set_interval_callback(std::function<void(const std::string &)> cb);
+  // Inform the JS side about the current interval during initialization.
+  void set_initial_interval(const std::string &interval);
   void end_frame(GLFWwindow *window);
   void shutdown();
 


### PR DESCRIPTION
## Summary
- build interval selector options dynamically and support additional intervals
- notify webview of initial interval on startup
- handle initial interval messages from JS

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a5845fd5388327892790172a4b3095