### PR TITLE
Track failed fetches to avoid repeated requests

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -34,6 +34,7 @@ public:
   int run();
   const AppStatus &status() const { return status_; }
   void add_status(const std::string &msg);
+  void clear_failed_fetches();
 
 private:
   bool init_window();

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <set>
 #include <vector>
 
 #include "config_manager.h"
@@ -61,6 +62,7 @@ struct AppContext {
   };
   std::deque<FetchTask> fetch_queue;
   std::mutex fetch_mutex;
+  std::set<std::pair<std::string, std::string>> failed_fetches;
   std::size_t total_fetches = 0;
   std::size_t completed_fetches = 0;
   std::atomic<long long> next_fetch_time{0};


### PR DESCRIPTION
## Summary
- Track pair/interval fetch failures in `AppContext`
- Skip scheduling and retrying tasks for failed pairs
- Expose helper to clear failed fetch records

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdd8ac808327ab97f28b02575cbc