### PR TITLE
Persist ImGui layout configuration

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -514,9 +514,7 @@ void App::render_ui() {
 
   ImGuiViewport *viewport = ImGui::GetMainViewport();
   ImGuiID dockspace_id = ImGui::DockSpaceOverViewport(viewport->ID, viewport);
-  static bool dock_init = false;
-  if (!dock_init) {
-    dock_init = true;
+  if (ImGui::DockBuilderGetNode(dockspace_id) == nullptr) {
     ImGui::DockBuilderRemoveNode(dockspace_id);
     ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_DockSpace);
     ImGuiID dock_main_top, dock_bottom;

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -20,7 +20,11 @@ UiManager::~UiManager() = default;
 bool UiManager::setup(GLFWwindow *window) {
   IMGUI_CHECKVERSION();
   ImGui::CreateContext();
+  const auto ini_path = Core::path_from_executable("imgui.ini");
+  std::filesystem::create_directories(ini_path.parent_path());
+  static std::string ini_path_str = ini_path.string();
   ImGuiIO &io = ImGui::GetIO();
+  io.IniFilename = ini_path_str.c_str();
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
   ImGui::StyleColorsDark();
   ImGui_ImplGlfw_InitForOpenGL(window, true);


### PR DESCRIPTION
## Summary
- Build dockspace layout only when no node exists to respect saved configurations
- Store ImGui ini beside executable and ensure parent path exists

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a5c7490c4c83279d9bacc8aa8a7ea1