### PR TITLE
Use callbacks for webview window readiness

### DIFF
--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -27,6 +27,7 @@ class EChartsWindow {
 
   // Show the window and start the event loop.
   void Show();
+
   // Retrieve the native window handle so it can be embedded inside an
   // ImGui region.
   void *GetNativeHandle() const;
@@ -42,6 +43,12 @@ class EChartsWindow {
   // `window.receiveFromCpp` to receive it.
   void SendToJs(const nlohmann::json &data);
 
+  // Set callback to receive the native handle once the window is ready.
+  void SetHandleCallback(std::function<void(void *)> cb);
+
+  // Set callback for reporting errors during initialization.
+  void SetErrorCallback(std::function<void(const std::string &)> cb);
+
  private:
   std::string html_path_;
   bool debug_;
@@ -50,6 +57,8 @@ class EChartsWindow {
   std::unique_ptr<webview::webview> view_;
   std::atomic<void *> native_handle_{nullptr};
 #endif
+  std::function<void(void *)> handle_callback_;
+  std::function<void(const std::string &)> error_callback_;
   nlohmann::json init_data_{};
 };
 
@@ -62,5 +71,8 @@ inline void EChartsWindow::Close() {}
 inline void EChartsWindow::SendToJs(const nlohmann::json&) {}
 inline void *EChartsWindow::GetNativeHandle() const { return nullptr; }
 inline void EChartsWindow::SetSize(int, int) {}
+inline void EChartsWindow::SetHandleCallback(std::function<void(void *)>) {}
+inline void EChartsWindow::SetErrorCallback(
+    std::function<void(const std::string &)>) {}
 #endif
 

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -39,4 +40,5 @@ private:
   std::function<void(const std::string &)> status_callback_;
   std::string echarts_error_;
   std::mutex echarts_mutex_;
+  std::atomic<void *> echarts_native_handle_{nullptr};
 };


### PR DESCRIPTION
## Summary
- Retrieve webview handle only after the window is initialized via `dispatch`
- Report initialization errors to UI manager and propagate native handle when ready
- Store and display native handle from `UiManager`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "unofficial-webview2")*


------
https://chatgpt.com/codex/tasks/task_e_68a5cb7aa3948327a4deddc6fe1a784b