### PR TITLE
Use condition variable for fetch thread

### DIFF
--- a/src/app_context.h
+++ b/src/app_context.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <future>
@@ -62,6 +63,7 @@ struct AppContext {
   };
   std::deque<FetchTask> fetch_queue;
   std::mutex fetch_mutex;
+  std::condition_variable fetch_cv;
   std::set<std::pair<std::string, std::string>> failed_fetches;
   std::size_t total_fetches = 0;
   std::size_t completed_fetches = 0;


### PR DESCRIPTION
## Summary
- manage fetch queue with a condition variable to avoid busy wait
- notify waiting thread when tasks are queued or shutdown

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ccd20b9c83278bf15c44e2a25edb