### PR TITLE
Load candle data asynchronously in UI

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -6,6 +6,7 @@
 #include <nlohmann/json.hpp>
 #include <thread>
 #include <utility>
+#include <chrono>
 
 #include "core/candle_manager.h"
 #include "core/logger.h"
@@ -50,9 +51,10 @@ bool UiManager::setup(GLFWwindow *window) {
   } else {
     echarts_window_ = std::make_unique<EChartsWindow>(html_path.string());
 
-    Core::CandleManager cm;
-    auto data = cm.load_candles_json("BTCUSDT", "1m");
-    echarts_window_->SetInitData(std::move(data));
+    candle_future_ = std::async(std::launch::async, []() {
+      Core::CandleManager cm;
+      return cm.load_candles_json("BTCUSDT", "1m");
+    });
 
     echarts_window_->SetHandleCallback([this](void *handle) {
       echarts_native_handle_.store(handle);
@@ -138,10 +140,25 @@ void UiManager::draw_echarts_panel(const std::string &selected_interval) {
       std::lock_guard<std::mutex> lock(echarts_mutex_);
       err = echarts_error_;
     }
+    if (!candles_loaded_ && candle_future_.valid() &&
+        echarts_native_handle_.load()) {
+      if (candle_future_.wait_for(std::chrono::seconds(0)) ==
+          std::future_status::ready) {
+        try {
+          auto data = candle_future_.get();
+          echarts_window_->SendToJs(data);
+        } catch (const std::exception &e) {
+          Core::Logger::instance().error(e.what());
+        }
+        candles_loaded_ = true;
+      }
+    }
     if (!err.empty()) {
       ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
                          "Failed to load chart");
       ImGui::TextWrapped("%s", err.c_str());
+    } else if (!candles_loaded_) {
+      ImGui::Text("Loading...");
     } else if (echarts_window_) {
       if (selected_interval != current_interval_) {
         echarts_window_->SendToJs(

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -6,6 +6,8 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <future>
+#include <nlohmann/json.hpp>
 
 #include "ui/echarts_window.h"
 
@@ -41,4 +43,6 @@ private:
   std::string echarts_error_;
   std::mutex echarts_mutex_;
   std::atomic<void *> echarts_native_handle_{nullptr};
+  std::future<nlohmann::json> candle_future_;
+  bool candles_loaded_ = false;
 };


### PR DESCRIPTION
## Summary
- Load candlestick data in a background task instead of blocking UI
- Show "Loading..." in Chart panel until data arrives
- Send loaded candle JSON to webview via `SendToJs`

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a5ced5f2348327adc576fd306f71b7