### PR TITLE
Refactor candle initialization for ECharts

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -4,10 +4,9 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
-#include <future>
-#include <nlohmann/json.hpp>
 
 #include "ui/echarts_window.h"
 
@@ -43,6 +42,4 @@ private:
   std::string echarts_error_;
   std::mutex echarts_mutex_;
   std::atomic<void *> echarts_native_handle_{nullptr};
-  std::future<nlohmann::json> candle_future_;
-  bool candles_loaded_ = false;
 };


### PR DESCRIPTION
## Summary
- Preload candle data before starting webview and set it as ECharts init data
- Simplify chart panel to rely on init handshake instead of one-time send

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a5d6a5057883278daba30f37b02533