### PR TITLE
Remove ImGui webview embedding

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -17,10 +17,6 @@ void EChartsWindow::SetInitData(nlohmann::json data) {
   init_data_ = std::move(data);
 }
 
-void EChartsWindow::SetHandleCallback(std::function<void(void *)> cb) {
-  handle_callback_ = std::move(cb);
-}
-
 void EChartsWindow::SetErrorCallback(
     std::function<void(const std::string &)> cb) {
   error_callback_ = std::move(cb);
@@ -33,24 +29,6 @@ void EChartsWindow::Show() {
 
   view_->set_title("ECharts");
   view_->set_size(800, 600, WEBVIEW_HINT_NONE);
-
-  view_->dispatch([this]() {
-    auto handle_result = view_->window();
-    if (handle_result.ok()) {
-      native_handle_.store(handle_result.value());
-      if (handle_callback_) {
-        handle_callback_(handle_result.value());
-      }
-    } else {
-      std::string msg =
-          std::string("Failed to get native window handle: ") +
-          handle_result.error().message();
-      Core::Logger::instance().error(msg);
-      if (error_callback_) {
-        error_callback_(msg);
-      }
-    }
-  });
 
   view_->bind("bridge", [this](std::string req) -> std::string {
     nlohmann::json json;
@@ -93,8 +71,6 @@ void EChartsWindow::Close() {
     view_->dispatch([](auto &wv) { wv.terminate(); });
   }
 }
-
-void *EChartsWindow::GetNativeHandle() const { return native_handle_.load(); }
 
 void EChartsWindow::SetSize(int width, int height) {
   if (view_) {

--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <atomic>
 #include <memory>
 #include <string>
 
@@ -28,11 +27,7 @@ class EChartsWindow {
   // Show the window and start the event loop.
   void Show();
 
-  // Retrieve the native window handle so it can be embedded inside an
-  // ImGui region.
-  void *GetNativeHandle() const;
-
-  // Resize the underlying webview to match the available ImGui space.
+  // Resize the underlying webview window.
   void SetSize(int width, int height);
 
   // Close the window and terminate the event loop so the hosting thread
@@ -43,9 +38,6 @@ class EChartsWindow {
   // `window.receiveFromCpp` to receive it.
   void SendToJs(const nlohmann::json &data);
 
-  // Set callback to receive the native handle once the window is ready.
-  void SetHandleCallback(std::function<void(void *)> cb);
-
   // Set callback for reporting errors during initialization.
   void SetErrorCallback(std::function<void(const std::string &)> cb);
 
@@ -55,9 +47,7 @@ class EChartsWindow {
   JsonHandler handler_;
 #if USE_WEBVIEW
   std::unique_ptr<webview::webview> view_;
-  std::atomic<void *> native_handle_{nullptr};
 #endif
-  std::function<void(void *)> handle_callback_;
   std::function<void(const std::string &)> error_callback_;
   nlohmann::json init_data_{};
 };
@@ -69,9 +59,7 @@ inline void EChartsWindow::SetInitData(nlohmann::json) {}
 inline void EChartsWindow::Show() {}
 inline void EChartsWindow::Close() {}
 inline void EChartsWindow::SendToJs(const nlohmann::json&) {}
-inline void *EChartsWindow::GetNativeHandle() const { return nullptr; }
 inline void EChartsWindow::SetSize(int, int) {}
-inline void EChartsWindow::SetHandleCallback(std::function<void(void *)>) {}
 inline void EChartsWindow::SetErrorCallback(
     std::function<void(const std::string &)>) {}
 #endif

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -58,9 +58,6 @@ bool UiManager::setup(GLFWwindow *window) {
       Core::Logger::instance().error(e.what());
     }
 
-    echarts_window_->SetHandleCallback(
-        [this](void *handle) { echarts_native_handle_.store(handle); });
-
     echarts_window_->SetErrorCallback([this](const std::string &msg) {
       {
         std::lock_guard<std::mutex> lock(echarts_mutex_);
@@ -154,15 +151,7 @@ void UiManager::draw_echarts_panel(const std::string &selected_interval) {
       ImVec2 avail = ImGui::GetContentRegionAvail();
       echarts_window_->SetSize(static_cast<int>(avail.x),
                                static_cast<int>(avail.y));
-      ImGui::BeginChild("EChartsView", ImVec2(0, 0), false,
-                        ImGuiWindowFlags_NoScrollbar |
-                            ImGuiWindowFlags_NoScrollWithMouse);
-      if (void *handle = echarts_native_handle_.load()) {
-        ImGui::Image(reinterpret_cast<ImTextureID>(handle), avail);
-      } else {
-        ImGui::Text("Loading chart...");
-      }
-      ImGui::EndChild();
+      ImGui::Text("Chart is displayed in a separate window.");
     } else {
       ImGui::Text("Loading chart...");
     }

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -41,5 +40,4 @@ private:
   std::function<void(const std::string &)> status_callback_;
   std::string echarts_error_;
   std::mutex echarts_mutex_;
-  std::atomic<void *> echarts_native_handle_{nullptr};
 };


### PR DESCRIPTION
## Summary
- treat ECharts webview as separate window instead of embedding in ImGui
- drop native handle plumbing and image rendering

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a5d854fa70832782b0af9e1ac6d579