### PR TITLE
Use #ifdef for USE_WEBVIEW

### DIFF
--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -5,7 +5,7 @@
 #include <string>
 
 #include <nlohmann/json.hpp>
-#if USE_WEBVIEW
+#ifdef USE_WEBVIEW
 #include <webview.h>
 #endif
 
@@ -45,7 +45,7 @@ class EChartsWindow {
   std::string html_path_;
   bool debug_;
   JsonHandler handler_;
-#if USE_WEBVIEW
+#ifdef USE_WEBVIEW
   std::unique_ptr<webview::webview> view_;
 #endif
   std::function<void(const std::string &)> error_callback_;

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -35,7 +35,7 @@ bool UiManager::setup(GLFWwindow *window) {
   if (auto cfg = Config::ConfigManager::load(resolve_config_path().string())) {
     chart_enabled_ = cfg->enable_chart;
   }
-#if USE_WEBVIEW
+#ifdef USE_WEBVIEW
   if (chart_enabled_) {
   const auto html_path = Core::path_from_executable("resources/chart.html");
   const auto js_path =
@@ -134,7 +134,7 @@ void UiManager::begin_frame() {
 
 void UiManager::draw_echarts_panel(const std::string &selected_interval) {
   ImGui::Begin("Chart");
-#if USE_WEBVIEW
+#ifdef USE_WEBVIEW
   if (!chart_enabled_) {
     ImGui::Text("Chart disabled by configuration");
   } else if (!resources_available_) {
@@ -191,7 +191,7 @@ void UiManager::set_status_callback(
 
 void UiManager::set_initial_interval(const std::string &interval) {
   current_interval_ = interval;
-#if USE_WEBVIEW
+#ifdef USE_WEBVIEW
   if (echarts_window_) {
     echarts_window_->SendToJs(nlohmann::json{{"interval", interval}});
   }


### PR DESCRIPTION
## Summary
- Replace `#if USE_WEBVIEW` with `#ifdef USE_WEBVIEW` in UI manager and ECharts window

## Testing
- `g++ -std=c++17 -DImGuiConfigFlags_DockingEnable=0 -I include -I src -I third_party/imgui -I third_party/imgui/backends -c src/ui/ui_manager.cpp -o /tmp/ui_manager_webview_off.o`
- `g++ -std=c++17 -DUSE_WEBVIEW -DImGuiConfigFlags_DockingEnable=0 -I include -I src -I third_party/imgui -I third_party/imgui/backends -I ports/webview/include -c src/ui/ui_manager.cpp -o /tmp/ui_manager_webview_on.o` *(fails: expected '}' before 'else')*

------
https://chatgpt.com/codex/tasks/task_e_68a60783cc308327976fddc56e7d722c