### PR TITLE
Use zero-arg dispatch callbacks in EChartsWindow

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -61,21 +61,21 @@ void EChartsWindow::SendToJs(const nlohmann::json &data) {
   if (view_) {
     std::string script =
         std::string("window.receiveFromCpp(") + data.dump() + ");";
-    view_->dispatch([s = std::move(script)](auto &wv) { wv.eval(s); });
+    view_->dispatch([this, s = std::move(script)]() { view_->eval(s); });
   }
 }
 
 void EChartsWindow::Close() {
   if (view_) {
     // Terminate the webview event loop so the hosting thread can finish.
-    view_->dispatch([](auto &wv) { wv.terminate(); });
+    view_->dispatch([this]() { view_->terminate(); });
   }
 }
 
 void EChartsWindow::SetSize(int width, int height) {
   if (view_) {
-    view_->dispatch([width, height](auto &wv) {
-      wv.set_size(width, height, WEBVIEW_HINT_NONE);
+    view_->dispatch([this, width, height]() {
+      view_->set_size(width, height, WEBVIEW_HINT_NONE);
     });
   }
 }


### PR DESCRIPTION
## Summary
- wrap webview dispatch calls in zero-argument lambdas capturing needed context
- ensure window sizing and closing use view_ methods inside lambda

## Testing
- `g++ -std=c++20 $(pkg-config --cflags gtk+-3.0 webkit2gtk-4.1) -Iinclude -Isrc -Ithird_party/webview_legacy -DUSE_WEBVIEW=1 -c src/ui/echarts_window.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68a60b3f8ecc83278880a1d61bbfb83c