### PR TITLE
Fix unmatched else in UiManager setup

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -115,7 +115,9 @@ bool UiManager::setup(GLFWwindow *window) {
         }
       }
     });
-  } else {
+  }
+  }
+  else {
     Core::Logger::instance().info("Chart disabled by configuration");
   }
 #else


### PR DESCRIPTION
## Summary
- close the `if (!resources_available_)` else block in `UiManager::setup`
- align outer `else` with `if (chart_enabled_)`

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: test_kline_stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a6266f21f0832793eb56a2304bc3fc