### PR TITLE
Use native window handle when creating ECharts webview

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -5,9 +5,11 @@
 
 #include "core/logger.h"
 
-EChartsWindow::EChartsWindow(const std::string &html_path, bool debug)
-    : html_path_(html_path), debug_(debug),
-      view_(std::make_unique<webview::webview>(debug, nullptr)) {}
+EChartsWindow::EChartsWindow(const std::string &html_path,
+                             void *parent_window,
+                             bool debug)
+    : html_path_(html_path), parent_window_(parent_window), debug_(debug),
+      view_(std::make_unique<webview::webview>(debug, parent_window)) {}
 
 void EChartsWindow::SetHandler(JsonHandler handler) {
   handler_ = std::move(handler);
@@ -24,7 +26,7 @@ void EChartsWindow::SetErrorCallback(
 
 void EChartsWindow::Show() {
   if (!view_) {
-    view_ = std::make_unique<webview::webview>(debug_, nullptr);
+    view_ = std::make_unique<webview::webview>(debug_, parent_window_);
   }
 
   view_->set_title("ECharts");

--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -16,7 +16,9 @@ class EChartsWindow {
   using JsonHandler =
       std::function<nlohmann::json(const nlohmann::json &request)>;
 
-  explicit EChartsWindow(const std::string &html_path, bool debug = false);
+  explicit EChartsWindow(const std::string &html_path,
+                         void *parent_window,
+                         bool debug = false);
 
   // Set handler that will be invoked when JavaScript sends JSON via the bridge.
   void SetHandler(JsonHandler handler);
@@ -43,6 +45,7 @@ class EChartsWindow {
 
  private:
   std::string html_path_;
+  void *parent_window_;
   bool debug_;
   JsonHandler handler_;
 #ifdef USE_WEBVIEW
@@ -53,7 +56,7 @@ class EChartsWindow {
 };
 
 #ifndef USE_WEBVIEW
-inline EChartsWindow::EChartsWindow(const std::string&, bool) {}
+inline EChartsWindow::EChartsWindow(const std::string&, void*, bool) {}
 inline void EChartsWindow::SetHandler(JsonHandler) {}
 inline void EChartsWindow::SetInitData(nlohmann::json) {}
 inline void EChartsWindow::Show() {}


### PR DESCRIPTION
## Summary
- Allow EChartsWindow to accept a native parent window pointer and pass it to webview
- Retrieve platform specific GLFW native window handle and forward to EChartsWindow
- Prepare webview to resize within the host window

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "unofficial-webview2")*
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF && cmake --build build -j2` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a6326358b4832782b4f157a3c138a9