### PR TITLE
Create webview on show thread and reset after close

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -5,11 +5,9 @@
 
 #include "core/logger.h"
 
-EChartsWindow::EChartsWindow(const std::string &html_path,
-                             void *parent_window,
+EChartsWindow::EChartsWindow(const std::string &html_path, void *parent_window,
                              bool debug)
-    : html_path_(html_path), parent_window_(parent_window), debug_(debug),
-      view_(std::make_unique<webview::webview>(debug, parent_window)) {}
+    : html_path_(html_path), parent_window_(parent_window), debug_(debug) {}
 
 void EChartsWindow::SetHandler(JsonHandler handler) {
   handler_ = std::move(handler);
@@ -57,6 +55,8 @@ void EChartsWindow::Show() {
   }
   view_->navigate(url);
   view_->run();
+  // After the event loop exits, free webview resources on this thread.
+  view_.reset();
 }
 
 void EChartsWindow::SendToJs(const nlohmann::json &data) {


### PR DESCRIPTION
## Summary
- Construct the webview lazily inside `EChartsWindow::Show` so it's created on the same thread as `run`
- Release webview resources when the event loop ends
- Keep `Close` focused on terminating the event loop

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest")*

------
https://chatgpt.com/codex/tasks/task_e_68a640f781d88327841cb446025a627a