### PR TITLE
Ensure UiManager joins thread on destruction

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -41,4 +41,5 @@ private:
   std::function<void(const std::string &)> status_callback_;
   std::string echarts_error_;
   std::mutex echarts_mutex_;
+  bool shutdown_called_ = false;
 };


### PR DESCRIPTION
## Summary
- Join and assert ECharts thread shutdown in UiManager destructor
- Make UiManager::shutdown idempotent with guard flag

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a6c51b91048327a5037bddff10e097