### PR TITLE
Add chart resource preparation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ Standalone C++ trading terminal using ImGui with an embedded chart powered by [A
 исполняемого файла и по умолчанию равны `resources/chart.html` и
 `third_party/echarts/echarts.min.js` соответственно.
 
+## Подготовка графика
+
+Перед запуском приложения скопируйте необходимые файлы графика в каталог сборки:
+
+```
+prepare_chart_resources.bat <путь_к_сборке>
+```
+
+Скрипт перенесёт `resources/chart.html` и `third_party/echarts/echarts.min.js` в указанную папку.
+
 ## График
 
 График свечей отображается через ECharts. Доступны стандартные возможности масштабирования и прокрутки; пользовательские инструменты рисования пока не поддерживаются.

--- a/prepare_chart_resources.bat
+++ b/prepare_chart_resources.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Usage: %~nx0 ^<build_path^>
+    exit /b 1
+)
+
+set "BUILD_DIR=%~1"
+
+robocopy "resources" "%BUILD_DIR%\resources" "chart.html" /NFL /NDL /NJH /NJS /NC /NS /NP >nul
+if errorlevel 8 (
+    echo Failed to copy chart.html
+    exit /b 1
+)
+
+robocopy "third_party\echarts" "%BUILD_DIR%\third_party\echarts" "echarts.min.js" /NFL /NDL /NJH /NJS /NC /NS /NP >nul
+if errorlevel 8 (
+    echo Failed to copy echarts.min.js
+    exit /b 1
+)
+
+echo Chart resources prepared.
+exit /b 0


### PR DESCRIPTION
## Summary
- add `prepare_chart_resources.bat` for copying chart resources into a chosen build directory
- document chart resource preparation in `README.md`

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d485efa483279535252b56732e59