### PR TITLE
Allow configuring ECharts script path and improve errors

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -5,9 +5,11 @@
 
 #include "core/logger.h"
 
-EChartsWindow::EChartsWindow(const std::string &html_path, void *parent_window,
-                             bool debug)
-    : html_path_(html_path), parent_window_(parent_window), debug_(debug) {}
+EChartsWindow::EChartsWindow(const std::string &html_path,
+                             const std::string &js_path,
+                             void *parent_window, bool debug)
+    : html_path_(html_path), js_path_(js_path), parent_window_(parent_window),
+      debug_(debug) {}
 
 void EChartsWindow::SetHandler(JsonHandler handler) {
   handler_ = std::move(handler);
@@ -34,7 +36,7 @@ void EChartsWindow::Show() {
     return;
   }
 
-  const std::filesystem::path js_path("third_party/echarts/echarts.min.js");
+  const std::filesystem::path js_path(js_path_);
   if (!std::filesystem::exists(js_path)) {
     const std::string msg = "ECharts script not found: " + js_path.string();
     if (error_callback_) {

--- a/src/ui/echarts_window.h
+++ b/src/ui/echarts_window.h
@@ -17,6 +17,7 @@ class EChartsWindow {
       std::function<nlohmann::json(const nlohmann::json &request)>;
 
   explicit EChartsWindow(const std::string &html_path,
+                         const std::string &js_path,
                          void *parent_window,
                          bool debug = false);
 
@@ -45,6 +46,7 @@ class EChartsWindow {
 
  private:
   std::string html_path_;
+  std::string js_path_;
   void *parent_window_;
   bool debug_;
   JsonHandler handler_;
@@ -56,7 +58,7 @@ class EChartsWindow {
 };
 
 #ifndef USE_WEBVIEW
-inline EChartsWindow::EChartsWindow(const std::string&, void*, bool) {}
+inline EChartsWindow::EChartsWindow(const std::string&, const std::string&, void*, bool) {}
 inline void EChartsWindow::SetHandler(JsonHandler) {}
 inline void EChartsWindow::SetInitData(nlohmann::json) {}
 inline void EChartsWindow::Show() {}

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <nlohmann/json.hpp>
 #include <thread>
+#include <typeinfo>
 #include <utility>
 
 #include "config_manager.h"
@@ -83,8 +84,8 @@ bool UiManager::setup(GLFWwindow *window) {
 #elif defined(__linux__)
       native_handle = reinterpret_cast<void *>(glfwGetX11Window(window));
 #endif
-      echarts_window_ =
-          std::make_unique<EChartsWindow>(html_path.string(), native_handle);
+      echarts_window_ = std::make_unique<EChartsWindow>(
+          html_path.string(), js_path.string(), native_handle);
 
       try {
         Core::CandleManager cm;
@@ -122,8 +123,12 @@ bool UiManager::setup(GLFWwindow *window) {
         try {
           echarts_window_->Show();
         } catch (const std::exception &e) {
+          std::string err = e.what();
+          if (err.empty()) {
+            err = typeid(e).name();
+          }
           const std::string msg =
-              std::string("Failed to run ECharts window: ") + e.what();
+              std::string("Failed to run ECharts window: ") + err;
           Core::Logger::instance().error(msg);
           {
             std::lock_guard<std::mutex> lock(echarts_mutex_);


### PR DESCRIPTION
## Summary
- Pass configurable ECharts script path into `EChartsWindow`
- Use configured JavaScript path when validating resources
- Improve error reporting for ECharts window startup

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest" with any of the following names: GTestConfig.cmake, gtest-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8a6c688832785042ff82b64daf6