### PR TITLE
Handle missing WebView2 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Standalone C++ trading terminal using ImGui with an embedded chart powered by [A
 4. Запусти `TradingTerminal.exe`
 
 📌 Требуется установленный `vcpkg` и предварительная загрузка зависимостей
+📌 Для работы встроенного графика установите [Microsoft Edge WebView2 runtime](https://developer.microsoft.com/microsoft-edge/webview2/)
 
 ## Сборка
 

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -124,11 +124,19 @@ bool UiManager::setup(GLFWwindow *window) {
           echarts_window_->Show();
         } catch (const std::exception &e) {
           std::string err = e.what();
+          const std::string type_name = typeid(e).name();
           if (err.empty()) {
-            err = typeid(e).name();
+            err = type_name;
           }
-          const std::string msg =
-              std::string("Failed to run ECharts window: ") + err;
+
+          std::string msg;
+          if (type_name.find("webview::exception") != std::string::npos) {
+            msg =
+                "WebView2 runtime not found. Install Microsoft Edge WebView2.";
+          } else {
+            msg = std::string("Failed to run ECharts window: ") + err;
+          }
+
           Core::Logger::instance().error(msg);
           {
             std::lock_guard<std::mutex> lock(echarts_mutex_);


### PR DESCRIPTION
## Summary
- detect `webview::exception` when showing ECharts window and present a clear WebView2 runtime missing message
- document WebView2 runtime requirement in README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest")*
- `ctest --test-dir build --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3f731d883279dd14ba114c0c6ef