### PR TITLE
Install Python dependencies before launching app

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -62,6 +62,27 @@ if %errorlevel% neq 0 (
     exit /b %errorlevel%
 )
 
+REM Ensure Python is available and install required packages
+where python >nul 2>nul
+if %errorlevel% neq 0 (
+    echo Python not found. Please install Python and ensure it is in your PATH.
+    pause
+    exit /b %errorlevel%
+)
+
+python -m pip install --upgrade pip
+if %errorlevel% neq 0 (
+    echo Failed to upgrade pip.
+    pause
+    exit /b %errorlevel%
+)
+python -m pip install requests pandas mplfinance
+if %errorlevel% neq 0 (
+    echo Failed to install Python packages.
+    pause
+    exit /b %errorlevel%
+)
+
 echo Launching the application...
 if exist "Debug\TradingTerminal.exe" (
     start "" "Debug\TradingTerminal.exe"


### PR DESCRIPTION
## Summary
- Ensure Python is available before running the trading terminal
- Upgrade pip and install requests, pandas, and mplfinance as part of setup

## Testing
- `pytest`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7197dad708327ae894ac837102ca9