### PR TITLE
Add WebView2 runtime installation check

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -2,6 +2,18 @@
 set SCRIPT_DIR=%~dp0
 set VCPKG_PATH=%SCRIPT_DIR%vcpkg
 
+REM Check for Microsoft Edge WebView2 Runtime
+reg query "HKLM\Software\Microsoft\EdgeUpdate\Clients" /s | findstr /I "WebView2" >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Microsoft Edge WebView2 Runtime not found. Attempting installation...
+    winget install -e --id Microsoft.EdgeWebView2Runtime
+    if %errorlevel% neq 0 (
+        echo WebView2 installation failed!
+        pause
+        exit /b %errorlevel%
+    )
+)
+
 REM Determine vcpkg path
 if exist "%VCPKG_PATH%" (
     echo Found vcpkg in script directory.


### PR DESCRIPTION
## Summary
- ensure setup script verifies Microsoft Edge WebView2 Runtime and installs via winget if missing

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest" with any of the following names: GTestConfig.cmake gtest-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ac3049c8327aa074958d476edba