### PR TITLE
Add error handling for WebView2 winget installation

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -12,9 +12,9 @@ if %EDGE_FOUND%==0 (
     echo Microsoft Edge WebView2 Runtime not found. Attempting installation...
     winget install -e --id Microsoft.EdgeWebView2Runtime
     if %errorlevel% neq 0 (
-        echo WebView2 installation failed!
-        pause
-        exit /b %errorlevel%
+        echo Failed to install Microsoft Edge WebView2 Runtime via winget.
+        echo Please ensure winget is available and try again.
+        exit /b 1
     )
     REM Recheck all registry locations after installation
     set EDGE_FOUND=0


### PR DESCRIPTION
## Summary
- capture errors after `winget install` of Microsoft Edge WebView2 Runtime
- exit early with an explanatory message when installation fails

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest")*

------
https://chatgpt.com/codex/tasks/task_e_68a72435d0c88327b41454b61e6359db