### PR TITLE
Check winget before WebView2 installation in setup script

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -1,4 +1,13 @@
 @echo off
+
+winget --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo winget is not installed.
+    echo Please install winget or download the Microsoft Edge WebView2 Runtime installer directly from:
+    echo https://go.microsoft.com/fwlink/p/?LinkId=2124703
+    exit /b 1
+)
+
 set SCRIPT_DIR=%~dp0
 set VCPKG_PATH=%SCRIPT_DIR%vcpkg
 


### PR DESCRIPTION
## Summary
- verify `winget` availability at the start of `setup_and_build.bat`
- instruct user to install `winget` or download the WebView2 runtime if missing

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7250cd9d48327a103a2a5199940d0