### PR TITLE
Initialize COM for ECharts thread on Windows

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -4,6 +4,7 @@
 #if defined(_WIN32)
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
+#include <Windows.h>
 #elif defined(__APPLE__)
 #define GLFW_EXPOSE_NATIVE_COCOA
 #include <GLFW/glfw3native.h>
@@ -120,6 +121,9 @@ bool UiManager::setup(GLFWwindow *window) {
         return nlohmann::json{};
       });
       echarts_thread_ = std::thread([this]() {
+#if defined(_WIN32)
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+#endif
         try {
           echarts_window_->Show();
         } catch (const std::exception &e) {
@@ -156,6 +160,9 @@ bool UiManager::setup(GLFWwindow *window) {
             status_callback_(msg);
           }
         }
+#if defined(_WIN32)
+        CoUninitialize();
+#endif
       });
     }
   } else {


### PR DESCRIPTION
## Summary
- Include `<Windows.h>` for Windows builds
- Initialize COM apartment for the ECharts thread and uninitialize on exit

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a733079df08327a10666813b3b9dcc