### PR TITLE
Ensure GLFW window resizable and set startup size

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -72,6 +72,7 @@ bool App::init_window() {
     Core::Logger::instance().error("Failed to initialize GLFW");
     return false;
   }
+  glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
   window_ = glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL);
   if (!window_) {
     Core::Logger::instance().error("Failed to create GLFW window");
@@ -79,6 +80,7 @@ bool App::init_window() {
     return false;
   }
   glfwMakeContextCurrent(window_);
+  glfwSetWindowSize(window_, 1280, 720);
   glfwSwapInterval(1);
   return true;
 }


### PR DESCRIPTION
## Summary
- Ensure GLFW window is resizable and initialized to 1280x720

## Testing
- `cmake -S . -B build` (fails: Could not find a package configuration file provided by "unofficial-webview2")

------
https://chatgpt.com/codex/tasks/task_e_68a737cbed44832786f6db5363328e5e