### PR TITLE
Refactor App logic into helper methods

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -46,6 +46,18 @@ private:
   void update_next_fetch_time(long long candidate);
   void schedule_retry(long long now_ms, std::chrono::milliseconds delay,
                       const std::string &msg = "");
+  void load_pairs(std::vector<std::string> &pair_names);
+  void load_existing_candles();
+  void start_initial_fetch_and_streams();
+  void schedule_http_updates(std::chrono::milliseconds period,
+                             long long now_ms);
+  void handle_http_updates();
+  void update_candle_progress();
+  void render_dockspace();
+  void render_status_window();
+  void render_main_windows();
+  void render_backtest_panel();
+  void handle_active_pair_change();
   void start_fetch_thread();
   void stop_fetch_thread();
 


### PR DESCRIPTION
## Summary
- Split `load_config`, `process_events`, and `render_ui` into smaller private helper functions for clarity
- Added helpers for loading pairs, handling HTTP updates, and rendering backtest and status panels

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "unofficial-webview2")*


------
https://chatgpt.com/codex/tasks/task_e_68a738a495048327a6db5f7b3fa52d4a