### PR TITLE
Use jthread for fetch worker

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -5,7 +5,6 @@
 #include "services/journal_service.h"
 #include "ui/ui_manager.h"
 
-#include <atomic>
 #include <chrono>
 #include <deque>
 #include <functional>
@@ -14,8 +13,8 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <vector>
 #include <thread>
+#include <vector>
 
 struct AppStatus {
   float candle_progress = 0.0f;
@@ -68,6 +67,5 @@ private:
   mutable std::mutex status_mutex_;
   GLFWwindow *window_ = nullptr;
   UiManager ui_manager_;
-  std::thread fetch_thread_;
-  std::atomic<bool> fetch_running_{false};
+  std::jthread fetch_thread_;
 };


### PR DESCRIPTION
## Summary
- replace manual fetch thread management with std::jthread and stop_token
- drop fetch_running flag and rely on stop requests

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest")*


------
https://chatgpt.com/codex/tasks/task_e_68a739f1e7e083278dcab50c3119514d