### PR TITLE
Refactor Gate symbol conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/interval_utils.cpp
     src/core/candle_utils.cpp
     src/core/data_dir.cpp
+    src/core/exchange_utils.cpp
     src/core/net/token_bucket_rate_limiter.cpp
     src/core/net/cpr_http_client.cpp
     src/core/backtester.cpp
@@ -166,6 +167,7 @@ add_executable(test_data_fetcher
   src/core/data_fetcher.cpp
   src/core/interval_utils.cpp
   src/core/candle_utils.cpp
+  src/core/exchange_utils.cpp
   src/candle.cpp
   src/core/logger.cpp
 )

--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -3,6 +3,7 @@
 #include "core/logger.h"
 #include "interval_utils.h"
 #include "candle_utils.h"
+#include "core/exchange_utils.h"
 #include <algorithm>
 #include <chrono>
 #include <future>
@@ -13,14 +14,6 @@
 #include <thread>
 
 namespace {
-
-std::string to_gate_symbol(const std::string &symbol) {
-  if (symbol.size() < 6)
-    return symbol;
-  std::string base = symbol.substr(0, symbol.size() - 4);
-  std::string quote = symbol.substr(symbol.size() - 4);
-  return base + "_" + quote;
-}
 
 std::string map_gate_interval(const std::string &interval) {
   static const std::unordered_map<std::string, std::string> mapping{{"5s", "10s"}};

--- a/src/core/exchange_utils.cpp
+++ b/src/core/exchange_utils.cpp
@@ -1,0 +1,10 @@
+#include "exchange_utils.h"
+
+std::string to_gate_symbol(const std::string &symbol) {
+  if (symbol.size() < 6)
+    return symbol;
+  std::string base = symbol.substr(0, symbol.size() - 4);
+  std::string quote = symbol.substr(symbol.size() - 4);
+  return base + "_" + quote;
+}
+

--- a/src/core/exchange_utils.h
+++ b/src/core/exchange_utils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+
+std::string to_gate_symbol(const std::string &symbol);
+

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -6,22 +6,11 @@
 #include "core/candle_utils.h"
 #include "config_manager.h"
 #include "config_path.h"
+#include "core/exchange_utils.h"
 
 #include <algorithm>
 #include <nlohmann/json.hpp>
 #include <thread>
-
-namespace {
-
-std::string to_gate_symbol(const std::string &symbol) {
-  if (symbol.size() < 6)
-    return symbol;
-  std::string base = symbol.substr(0, symbol.size() - 4);
-  std::string quote = symbol.substr(symbol.size() - 4);
-  return base + "_" + quote;
-}
-
-} // namespace
 
 DataService::DataService()
     : http_client_(std::make_shared<Core::CprHttpClient>()),


### PR DESCRIPTION
## Summary
- centralize Gate pair formatting into new exchange_utils module
- reuse to_gate_symbol in data_fetcher and data_service via header include
- add exchange_utils module to build system and tests

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a73b3c3f3483279e5270e2a8bfbd1b