### PR TITLE
Eliminate global Core namespace usage

### DIFF
--- a/src/ui/analytics_window.cpp
+++ b/src/ui/analytics_window.cpp
@@ -5,10 +5,9 @@
 #include <algorithm>
 #include <vector>
 
-using namespace Core;
 
 void DrawAnalyticsWindow(
-    const std::map<std::string, std::map<std::string, std::vector<Candle>>>& all_candles,
+    const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
     const std::string& active_pair,
     const std::string& selected_interval) {
     ImGui::Begin("Analytics");

--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -10,14 +10,13 @@
 #include <algorithm>
 #include <ctime>
 
-using namespace Core;
 
 void DrawSignalsWindow(
     std::string &strategy, int &short_period, int &long_period,
     double &oversold, double &overbought, bool &show_on_chart,
     std::vector<SignalEntry> &signal_entries,
     std::vector<AppContext::TradeEvent> &trades,
-    const std::map<std::string, std::map<std::string, std::vector<Candle>>>
+    const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>
         &all_candles,
     const std::string &active_pair, const std::string &selected_interval,
     AppStatus &status) {


### PR DESCRIPTION
## Summary
- remove `using namespace Core` from application, UI, and test files
- qualify references with `Core::` for candles, streams, fetch errors, etc.

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a743c344ac832787555c5a3799cd69