### PR TITLE
Refactor GLFW initialization with RAII context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/iwebsocket.cpp
     src/core/logger.cpp
     src/core/path_utils.cpp
+    src/core/glfw_context.cpp
     src/journal.cpp
     src/services/data_service.cpp
     src/services/journal_service.cpp

--- a/src/app.h
+++ b/src/app.h
@@ -4,6 +4,7 @@
 #include "services/data_service.h"
 #include "services/journal_service.h"
 #include "ui/ui_manager.h"
+#include "core/glfw_context.h"
 
 #include <chrono>
 #include <deque>
@@ -15,6 +16,8 @@
 #include <string>
 #include <thread>
 #include <vector>
+
+struct GLFWwindow;
 
 struct AppStatus {
   float candle_progress = 0.0f;
@@ -65,7 +68,11 @@ private:
   JournalService journal_service_;
   AppStatus status_;
   mutable std::mutex status_mutex_;
-  GLFWwindow *window_ = nullptr;
+  struct WindowDeleter {
+    void operator()(GLFWwindow *window) const;
+  };
+  std::unique_ptr<Core::GlfwContext> glfw_context_;
+  std::unique_ptr<GLFWwindow, WindowDeleter> window_{nullptr};
   UiManager ui_manager_;
   std::jthread fetch_thread_;
 };

--- a/src/core/glfw_context.cpp
+++ b/src/core/glfw_context.cpp
@@ -1,0 +1,15 @@
+#include "glfw_context.h"
+
+#include <GLFW/glfw3.h>
+
+namespace Core {
+
+GlfwContext::GlfwContext() { initialized_ = glfwInit(); }
+
+GlfwContext::~GlfwContext() {
+  if (initialized_)
+    glfwTerminate();
+}
+
+} // namespace Core
+

--- a/src/core/glfw_context.h
+++ b/src/core/glfw_context.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace Core {
+
+class GlfwContext {
+public:
+  GlfwContext();
+  ~GlfwContext();
+
+  GlfwContext(const GlfwContext &) = delete;
+  GlfwContext &operator=(const GlfwContext &) = delete;
+  GlfwContext(GlfwContext &&) = delete;
+  GlfwContext &operator=(GlfwContext &&) = delete;
+
+  bool initialized() const { return initialized_; }
+
+private:
+  bool initialized_ = false;
+};
+
+} // namespace Core
+


### PR DESCRIPTION
## Summary
- add GlfwContext RAII wrapper for glfwInit/glfwTerminate
- manage GLFWwindow with unique_ptr and automatic cleanup
- call App cleanup from destructor and drop manual glfwTerminate usage

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a74b36dee08327a1da3063fdaf8601