### PR TITLE
Fix EMA seeding logic and adjust tests

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -47,14 +47,18 @@ double exponential_moving_average(const std::vector<Core::Candle>& candles,
     if (period == 0 || index >= candles.size() || index + 1 < period) {
         return 0.0;
     }
+
     const double k = 2.0 / (static_cast<double>(period) + 1.0);
-    // Start with SMA for the first period
-    std::size_t start = index + 1 - period;
-    double ema = simple_moving_average(candles, index - (period > 1 ? 1 : 0), period);
-    for (std::size_t i = start; i <= index; ++i) {
-        ema = (candles[i].close - ema) * k + ema;
+
+    // For the first complete window, seed the EMA with the SMA at the
+    // current index to avoid relying on a previous index.
+    if (index + 1 == period) {
+        return simple_moving_average(candles, index, period);
     }
-    return ema;
+
+    // Recursively compute the previous EMA and update with the current price.
+    double prev_ema = exponential_moving_average(candles, index - 1, period);
+    return (candles[index].close - prev_ema) * k + prev_ema;
 }
 
 int ema_signal(const std::vector<Core::Candle>& candles,

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -90,7 +90,7 @@ TEST(SignalIndicators, CalculatesEmaAndRsi) {
         candles.emplace_back(i,0,0,0,closes[i],0,0,0,0,0,0,0);
     }
     double ema = Signal::exponential_moving_average(candles,4,3);
-    EXPECT_NEAR(ema, 4.25, 1e-2);
+    EXPECT_NEAR(ema, 4.0, 1e-2);
     double rsi = Signal::relative_strength_index(candles,4,3);
     EXPECT_NEAR(rsi, 100.0, 1e-6);
 }
@@ -102,15 +102,15 @@ TEST(SignalIndicators, CalculatesMacd) {
         candles.emplace_back(i,0,0,0,closes[i],0,0,0,0,0,0,0);
     }
     Signal::MACDResult res = Signal::macd(candles,5,2,3,2);
-    EXPECT_NEAR(res.macd, -0.3194444444, 1e-6);
-    EXPECT_NEAR(res.signal, -0.2546296296, 1e-6);
-    EXPECT_NEAR(res.histogram, -0.0648148148, 1e-6);
+    EXPECT_NEAR(res.macd, -0.1990740741, 1e-6);
+    EXPECT_NEAR(res.signal, -0.1234567901, 1e-6);
+    EXPECT_NEAR(res.histogram, -0.0756172840, 1e-6);
     for (int i = 1; i <= 50; ++i) {
         candles.emplace_back(i,0,0,0,i,0,0,0,0,0,0,0);
     }
     auto m = Signal::macd(candles, 49, 12, 26, 9);
-    EXPECT_NEAR(m.macd, 5.1017391484568435, 1e-6);
-    EXPECT_NEAR(m.signal, 5.1017391484568524, 1e-6);
-    EXPECT_NEAR(m.histogram, 0.0, 1e-6);
+    EXPECT_NEAR(m.macd, 6.8401731354, 1e-6);
+    EXPECT_NEAR(m.signal, 6.7908355919, 1e-6);
+    EXPECT_NEAR(m.histogram, 0.0493375435, 1e-6);
 }
 


### PR DESCRIPTION
## Summary
- Seed exponential moving average with the current window's SMA and compute EMA recursively
- Adjust EMA and MACD unit tests to match new calculation

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68a75be79c548327815047dab57137f1