### PR TITLE
Guard RSI signal on incomplete data

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -106,6 +106,10 @@ int rsi_signal(const std::vector<Core::Candle>& candles,
                std::size_t period,
                double oversold,
                double overbought) {
+    if (index + 1 < period) {
+        // RSI requires at least `period` candles before producing signals
+        return 0;
+    }
     double rsi = relative_strength_index(candles, index, period);
     if (rsi < oversold) {
         return 1;
@@ -113,7 +117,7 @@ int rsi_signal(const std::vector<Core::Candle>& candles,
     if (rsi > overbought) {
         return -1;
     }
-      return 0;
+    return 0;
   }
 
   // Calculates the MACD line (EMA(fast) - EMA(slow)).


### PR DESCRIPTION
## Summary
- Ensure RSI signal returns no signal when fewer than `period` candles are available
- Comment why dataset completeness is required before generating RSI-based signals

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a76143cab08327ad362f46aa60a1c1