### PR TITLE
Use Core::executable_dir for config path resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ add_executable(test_candle_manager
   src/candle.cpp
   src/core/logger.cpp
   src/config_path.cpp
+  src/core/path_utils.cpp
 )
 target_include_directories(test_candle_manager PRIVATE src include)
 target_link_libraries(test_candle_manager PRIVATE GTest::gtest_main)
@@ -203,6 +204,7 @@ add_executable(test_kline_stream
   src/candle.cpp
   src/core/logger.cpp
   src/config_path.cpp
+  src/core/path_utils.cpp
 )
 target_include_directories(test_kline_stream PRIVATE src include)
 target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)

--- a/src/config_path.cpp
+++ b/src/config_path.cpp
@@ -1,38 +1,8 @@
 #include "config_path.h"
+#include "core/path_utils.h"
 
 #include <array>
 #include <cstdlib>
-
-#ifdef _WIN32
-#include <windows.h>
-#elif __APPLE__
-#include <mach-o/dyld.h>
-#else
-#include <limits.h>
-#include <unistd.h>
-#endif
-
-namespace {
-std::filesystem::path executable_dir() {
-#ifdef _WIN32
-    wchar_t buffer[MAX_PATH];
-    DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
-    return std::filesystem::path(buffer, buffer + len).parent_path();
-#elif __APPLE__
-    char path[1024];
-    uint32_t size = sizeof(path);
-    if (_NSGetExecutablePath(path, &size) == 0)
-        return std::filesystem::path(path).parent_path();
-    return std::filesystem::current_path();
-#else
-    char result[PATH_MAX];
-    ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
-    if (count != -1)
-        return std::filesystem::path(std::string(result, count)).parent_path();
-    return std::filesystem::current_path();
-#endif
-}
-} // namespace
 
 std::filesystem::path resolve_config_path(const std::filesystem::path &filename) {
     if (filename.is_absolute()) {
@@ -44,7 +14,7 @@ std::filesystem::path resolve_config_path(const std::filesystem::path &filename)
     if (const char *env_cfg = std::getenv("CANDLE_CONFIG_PATH")) {
         return std::filesystem::path(env_cfg);
     }
-    auto exe_dir = executable_dir();
+    auto exe_dir = Core::executable_dir();
     std::array<std::filesystem::path, 3> candidates = {
         exe_dir / filename,
         exe_dir.parent_path() / filename,


### PR DESCRIPTION
## Summary
- remove anonymous `executable_dir` and include `core/path_utils.h`
- rely on `Core::executable_dir()` when resolving config paths
- link `path_utils.cpp` into test targets that use `resolve_config_path`

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build -j 2`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a762ff756c832798dfc5922762b5ee