### PR TITLE
refactor: extract config types

### DIFF
--- a/src/app_context.h
+++ b/src/app_context.h
@@ -13,7 +13,7 @@
 #include <set>
 #include <vector>
 
-#include "config_manager.h"
+#include "config_types.h"
 #include "core/backtester.h"
 #include "core/candle.h"
 #include "core/data_fetcher.h"

--- a/src/config_manager.h
+++ b/src/config_manager.h
@@ -1,36 +1,12 @@
 #pragma once
 
-#include <map>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include "core/logger.h"
+#include "config_types.h"
 
 namespace Config {
-
-struct SignalConfig {
-  std::string type{"sma_crossover"};
-  std::size_t short_period{0};
-  std::size_t long_period{0};
-  std::map<std::string, double> params{};
-};
-
-struct ConfigData {
-  std::vector<std::string> pairs{};
-  Core::LogLevel log_level{Core::LogLevel::Info};
-  bool log_to_file{true};
-  bool log_to_console{true};
-  std::string log_file{"terminal.log"};
-  std::size_t candles_limit{5000};
-  bool enable_chart{true};
-  std::string chart_html_path{"resources/chart.html"};
-  std::string echarts_js_path{"third_party/echarts/echarts.min.js"};
-  bool enable_streaming{false};
-  SignalConfig signal{};
-  std::string primary_provider{"binance"};
-  std::string fallback_provider{"gateio"};
-};
 
 class ConfigManager {
 public:

--- a/src/config_schema.h
+++ b/src/config_schema.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "config_manager.h"
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+
+#include "config_types.h"
 
 namespace Config {
 

--- a/src/config_types.h
+++ b/src/config_types.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "core/logger.h"
+
+namespace Config {
+
+struct SignalConfig {
+  std::string type{"sma_crossover"};
+  std::size_t short_period{0};
+  std::size_t long_period{0};
+  std::map<std::string, double> params{};
+};
+
+struct ConfigData {
+  std::vector<std::string> pairs{};
+  Core::LogLevel log_level{Core::LogLevel::Info};
+  bool log_to_file{true};
+  bool log_to_console{true};
+  std::string log_file{"terminal.log"};
+  std::size_t candles_limit{5000};
+  bool enable_chart{true};
+  std::string chart_html_path{"resources/chart.html"};
+  std::string echarts_js_path{"third_party/echarts/echarts.min.js"};
+  bool enable_streaming{false};
+  SignalConfig signal{};
+  std::string primary_provider{"binance"};
+  std::string fallback_provider{"gateio"};
+};
+
+} // namespace Config
+

--- a/src/services/signal_bot.h
+++ b/src/services/signal_bot.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "config_manager.h"
+#include "config_types.h"
 #include "core/backtester.h"
 #include "signal.h"
 


### PR DESCRIPTION
## Summary
- centralize SignalConfig and ConfigData in new config_types header
- include config_types where needed to reduce coupling

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a764abc6fc83279db6f98d40d8ebd3