### PR TITLE
Handle ticker failure in symbol fetch

### DIFF
--- a/tests/test_data_fetcher.cpp
+++ b/tests/test_data_fetcher.cpp
@@ -89,3 +89,14 @@ TEST(DataFetcherTest, AltApiRejectsUnsupportedInterval) {
   EXPECT_EQ(res.error, Core::FetchError::HttpError);
 }
 
+TEST(DataFetcherTest, TopSymbolsTickerFailureReturnsError) {
+  auto http = std::make_shared<FakeHttpClient>();
+  http->responses.push_back(
+      {200, R"({"symbols":[{"symbol":"AAA"}]})", "", false});
+  http->responses.push_back({0, "", "net fail", true});
+  auto limiter = std::make_shared<DummyLimiter>();
+  Core::DataFetcher fetcher(http, limiter);
+  auto res = fetcher.fetch_all_symbols();
+  EXPECT_EQ(res.error, Core::FetchError::NetworkError);
+}
+


### PR DESCRIPTION
## Summary
- propagate network/HTTP errors when fetching top symbols
- add unit test covering ticker failure path

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a769f18f308327ad923947370d3de9