### PR TITLE
Let webview inherit parent window size

### DIFF
--- a/src/ui/echarts_window.cpp
+++ b/src/ui/echarts_window.cpp
@@ -52,7 +52,8 @@ void EChartsWindow::Show() {
   }
 
   view_->set_title("ECharts");
-  view_->set_size(800, 600, WEBVIEW_HINT_NONE);
+  // Avoid forcing a fixed initial size.  Let the webview inherit the
+  // current dimensions from its parent window so users can freely resize.
 
   view_->bind("bridge", [this](std::string req) -> std::string {
     nlohmann::json json;


### PR DESCRIPTION
## Summary
- Remove hard-coded 800x600 size for ECharts webview so it uses parent window dimensions and remains resizable

## Testing
- `cmake --build build -j2`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a7cf46e7108327aa4b5146c02168c7