### PR TITLE
Allow window maximization in App::init_window

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -87,7 +87,7 @@ bool App::init_window() {
     return false;
   }
   glfwMakeContextCurrent(window_.get());
-  glfwSetWindowSize(window_.get(), 1280, 720);
+  glfwMaximizeWindow(window_.get());
   glfwSwapInterval(1);
   return true;
 }


### PR DESCRIPTION
## Summary
- Remove fixed window sizing and maximize the main window on startup

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "unofficial-webview2")*

------
https://chatgpt.com/codex/tasks/task_e_68a7d33dce64832785cdd2511b01b668