### PR TITLE
Add Lightweight Charts candle serialization

### DIFF
--- a/src/ui/echarts_serializer.cpp
+++ b/src/ui/echarts_serializer.cpp
@@ -10,3 +10,19 @@ nlohmann::json SerializeCandles(const std::vector<Core::Candle>& candles) {
     return nlohmann::json{{"x", x}, {"y", y}};
 }
 
+// Serialize candle data for TradingView Lightweight Charts. Returns an array
+// of objects with Unix-second timestamps and OHLC values.
+nlohmann::json SerializeCandlesTV(const std::vector<Core::Candle>& candles) {
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& c : candles) {
+        arr.push_back({
+            {"time", c.open_time / 1000LL}, // convert milliseconds to seconds
+            {"open", c.open},
+            {"high", c.high},
+            {"low", c.low},
+            {"close", c.close}
+        });
+    }
+    return arr;
+}
+

--- a/src/ui/echarts_serializer.h
+++ b/src/ui/echarts_serializer.h
@@ -8,3 +8,7 @@
 // matching ECharts candlestick expectations.
 nlohmann::json SerializeCandles(const std::vector<Core::Candle>& candles);
 
+// Serialize candles for TradingView Lightweight Charts. Each element is an
+// object with Unix-second "time" and OHLC fields.
+nlohmann::json SerializeCandlesTV(const std::vector<Core::Candle>& candles);
+

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -32,6 +32,7 @@
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 #include "ui/echarts_window.h"
+#include "ui/echarts_serializer.h"
 
 UiManager::~UiManager() {
   if (echarts_thread_.joinable()) {
@@ -115,8 +116,8 @@ bool UiManager::setup(GLFWwindow *window) {
 
       try {
         Core::CandleManager cm;
-        auto data = cm.load_candles_json("BTCUSDT", "1m");
-        echarts_window_->SetInitData(data);
+        auto candles = cm.load_candles("BTCUSDT", "1m");
+        echarts_window_->SetInitData(SerializeCandlesTV(candles));
       } catch (const std::exception &e) {
         Core::Logger::instance().error(e.what());
       }


### PR DESCRIPTION
## Summary
- add serializer producing TradingView-style candle objects
- feed serialized candle data into chart window initialization
- clarify UNIX-second conversion comment

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a85c854f748327a47ef94f52c9498a