### PR TITLE
Add TradingView candle JSON loader

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -302,6 +302,21 @@ nlohmann::json CandleManager::load_candles_json(const std::string& symbol,
     return nlohmann::json{{"x", std::move(x)}, {"y", std::move(y)}};
 }
 
+nlohmann::json CandleManager::load_candles_tradingview(const std::string& symbol,
+                                                        const std::string& interval) const {
+    auto candles = load_candles(symbol, interval);
+    nlohmann::json data = nlohmann::json::array();
+    for (const auto& c : candles) {
+        data.push_back({{"time", c.open_time / 1000},
+                        {"open", c.open},
+                        {"high", c.high},
+                        {"low", c.low},
+                        {"close", c.close},
+                        {"volume", c.volume}});
+    }
+    return data;
+}
+
 
 bool CandleManager::remove_candles(const std::string& symbol) const {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -31,6 +31,11 @@ public:
                                      std::size_t offset = 0,
                                      std::size_t limit = 0) const;
 
+    // Loads candles and converts them to TradingView compatible JSON
+    // array with fields time/open/high/low/close/volume.
+    nlohmann::json load_candles_tradingview(const std::string& symbol,
+                                            const std::string& interval) const;
+
     // Removes all files with the given symbol prefix (symbol_*).
     bool remove_candles(const std::string& symbol) const;
 

--- a/tests/test_candle_manager.cpp
+++ b/tests/test_candle_manager.cpp
@@ -105,3 +105,28 @@ TEST(CandleManagerTest, LoadCandlesJsonReturnsOHLC) {
     std::filesystem::remove_all(dir);
 }
 
+TEST(CandleManagerTest, LoadCandlesTradingViewFormat) {
+    using namespace Core;
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / "cm_tradingview_test";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    CandleManager cm(dir);
+
+    std::vector<Candle> candles = {
+        {0,10.0,20.0,5.0,15.0,1.0,59999,0.0,0,0.0,0.0,0.0},
+        {60000,12.0,22.0,8.0,18.0,2.0,119999,0.0,0,0.0,0.0,0.0}
+    };
+    cm.save_candles("TEST","1m",candles);
+
+    auto json = cm.load_candles_tradingview("TEST","1m");
+    ASSERT_EQ(json.size(), 2);
+    auto first = json[0];
+    EXPECT_EQ(first["time"].get<long long>(), 0);
+    EXPECT_DOUBLE_EQ(first["open"].get<double>(), 10.0);
+    EXPECT_DOUBLE_EQ(first["high"].get<double>(), 20.0);
+    EXPECT_DOUBLE_EQ(first["low"].get<double>(), 5.0);
+    EXPECT_DOUBLE_EQ(first["close"].get<double>(), 15.0);
+
+    std::filesystem::remove_all(dir);
+}
+


### PR DESCRIPTION
## Summary
- convert stored candles to TradingView format
- test TradingView JSON output

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a86a355fc083278162b57892bf71e1