### PR TITLE
Integrate TradingView chart and dynamic candle loading

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -1,15 +1,34 @@
 <!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"/></head>
+<head>
+  <meta charset="utf-8" />
+  <script src="lightweight-charts.standalone.production.js"></script>
+  <style>
+    html, body, #chart { width: 100%; height: 100%; margin: 0; padding: 0; }
+  </style>
+</head>
 <body>
-<!-- Chart placeholder. TradingView integration will be added later. -->
-<script>
-  // Minimal stub chart API for native<->JS communication tests.
-  window.chart = {
-    addCandle: function(c) { console.log('candle', c); },
-    setMarkers: function(m) { console.log('markers', m); },
-    setPriceLine: function(p) { console.log('price line', p); }
-  };
-</script>
+  <div id="chart"></div>
+  <script>
+    const chart = LightweightCharts.createChart(document.getElementById('chart'), {
+      width: document.body.clientWidth,
+      height: document.body.clientHeight,
+    });
+    const series = chart.addCandlestickSeries();
+    let priceLine;
+    function loadCandles(data) {
+      series.setData(data);
+    }
+    window.chart = {
+      addCandle: c => series.update(c),
+      setMarkers: m => series.setMarkers(m),
+      setPriceLine: p => {
+        if (priceLine) {
+          series.removePriceLine(priceLine);
+        }
+        priceLine = series.createPriceLine({ price: p, color: 'yellow', lineWidth: 1 });
+      }
+    };
+  </script>
 </body>
 </html>

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -620,7 +620,9 @@ void App::render_main_windows() {
                         this->ctx_->selected_interval);
     DrawJournalWindow(journal_service_);
   }
-  ui_manager_.draw_chart_panel(this->ctx_->selected_interval);
+  ui_manager_.draw_chart_panel(data_service_.candle_manager(),
+                               this->ctx_->active_pair,
+                               this->ctx_->selected_interval);
 }
 
 void App::render_backtest_panel() {

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <charconv>
 #include <string_view>
+#include <algorithm>
 #include "core/logger.h"
 #include "interval_utils.h"
 #include "core/data_dir.h"
@@ -300,6 +301,29 @@ nlohmann::json CandleManager::load_candles_json(const std::string& symbol,
         y.push_back({c.open, c.close, c.low, c.high});
     }
     return nlohmann::json{{"x", std::move(x)}, {"y", std::move(y)}};
+}
+
+nlohmann::json CandleManager::load_candles_tradingview(
+    const std::string& symbol, const std::string& interval,
+    std::size_t offset, std::size_t limit) const {
+    auto candles = load_candles(symbol, interval);
+    nlohmann::json arr = nlohmann::json::array();
+
+    if (offset >= candles.size()) {
+        return arr;
+    }
+
+    std::size_t end =
+        limit > 0 ? std::min(offset + limit, candles.size()) : candles.size();
+    for (std::size_t i = offset; i < end; ++i) {
+        const auto& c = candles[i];
+        arr.push_back({{"time", c.open_time / 1000},
+                       {"open", c.open},
+                       {"high", c.high},
+                       {"low", c.low},
+                       {"close", c.close}});
+    }
+    return arr;
 }
 
 

--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -31,6 +31,13 @@ public:
                                      std::size_t offset = 0,
                                      std::size_t limit = 0) const;
 
+    // Loads candles and converts them to an array of objects suitable for
+    // TradingView Lightweight Charts ({time, open, high, low, close}).
+    nlohmann::json load_candles_tradingview(const std::string& symbol,
+                                            const std::string& interval,
+                                            std::size_t offset = 0,
+                                            std::size_t limit = 0) const;
+
     // Removes all files with the given symbol prefix (symbol_*).
     bool remove_candles(const std::string& symbol) const;
 

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -12,6 +12,7 @@ class webview;
 }
 namespace Core {
 struct Candle;
+class CandleManager;
 }
 
 // Manages ImGui initialization and per-frame rendering and hosts auxiliary
@@ -22,7 +23,9 @@ public:
   bool setup(GLFWwindow *window);
   void begin_frame();
   // Draw docked panels each frame. Currently hosts a placeholder chart panel.
-  void draw_chart_panel(const std::string &selected_interval);
+  void draw_chart_panel(Core::CandleManager &candle_manager,
+                        const std::string &active_pair,
+                        const std::string &selected_interval);
   // Pushes trade markers to the chart via series.setMarkers.
   void set_markers(const std::string &markers_json);
   // Draws/updates a price line for the currently open position.
@@ -41,9 +44,11 @@ public:
 private:
   bool chart_enabled_ = true;
   std::string current_interval_;
+  std::string current_pair_;
   std::function<void(const std::string &)> on_interval_changed_;
   std::function<void(const std::string &)> status_callback_;
   std::unique_ptr<webview::webview> chart_view_;
+  std::string chart_html_path_;
   bool shutdown_called_ = false;
 
   // Throttling for real-time candle pushes


### PR DESCRIPTION
## Summary
- Replace stub chart page with TradingView Lightweight Charts and a `loadCandles` API
- Lazily create the chart webview and feed candles via `CandleManager::load_candles_tradingview`
- Only instantiate the chart when configuration `enable_chart` is true

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a86baa429483279282535dc273d402