### PR TITLE
Forward closed candles to UI and update chart

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -2,13 +2,24 @@
 <html>
 <head><meta charset="utf-8"/></head>
 <body>
-<!-- Chart placeholder. TradingView integration will be added later. -->
+<div id="tvchart" style="width:100%;height:100%;"></div>
+<script src="https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js"></script>
 <script>
-  // Minimal stub chart API for native<->JS communication tests.
+  const chart = LightweightCharts.createChart(document.getElementById('tvchart'), {width:600, height:300});
+  const series = chart.addCandlestickSeries();
+  const data = [];
+  window.updateCandle = function(c) {
+    if (data.length && data[data.length-1].time === c.time) {
+      data[data.length-1] = c;
+      series.update(c);
+    } else {
+      data.push(c);
+      series.update(c);
+    }
+  };
   window.chart = {
-    addCandle: function(c) { console.log('candle', c); },
-    setMarkers: function(m) { console.log('markers', m); },
-    setPriceLine: function(p) { console.log('price line', p); }
+    setMarkers: function(m) { series.setMarkers(m); },
+    setPriceLine: function(p) { series.createPriceLine({price:p}); }
   };
 </script>
 </body>

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -40,7 +40,6 @@ static void OnFramebufferResize(GLFWwindow * /*w*/, int width, int height) {
   glViewport(0, 0, width, height);
 }
 
-
 void App::WindowDeleter::operator()(GLFWwindow *window) const {
   if (window)
     glfwDestroyWindow(window);
@@ -83,8 +82,7 @@ bool App::init_window() {
     return false;
   }
   glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-  window_.reset(
-      glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL));
+  window_.reset(glfwCreateWindow(1280, 720, "Trading Terminal", NULL, NULL));
   if (!window_) {
     Core::Logger::instance().error("Failed to create GLFW window");
     glfw_context_.reset();
@@ -175,9 +173,10 @@ void App::load_pairs(std::vector<std::string> &pair_names) {
       this->ctx_->intervals.empty() ? "1m" : this->ctx_->intervals[0];
 
   auto exchange_pairs_res = data_service_.fetch_all_symbols();
-  this->ctx_->exchange_pairs = exchange_pairs_res.error == Core::FetchError::None
-                                   ? exchange_pairs_res.symbols
-                                   : std::vector<std::string>{};
+  this->ctx_->exchange_pairs =
+      exchange_pairs_res.error == Core::FetchError::None
+          ? exchange_pairs_res.symbols
+          : std::vector<std::string>{};
 
   this->ctx_->selected_interval =
       this->ctx_->intervals.empty() ? "1m" : this->ctx_->intervals[0];
@@ -280,7 +279,8 @@ void App::start_initial_fetch_and_streams() {
             this->ctx_->stream_failed = true;
             this->ctx_->next_fetch_time.store(0);
             add_status("Stream failed for " + pair + ", switching to HTTP");
-          });
+          },
+          ui_manager_.candle_callback());
       this->ctx_->streams[pair] = std::move(stream);
     }
   } else {
@@ -327,7 +327,8 @@ void App::start_fetch_thread() {
         auto status = it->future.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
           auto fetched = it->future.get();
-          if (fetched.error == Core::FetchError::None && !fetched.candles.empty()) {
+          if (fetched.error == Core::FetchError::None &&
+              !fetched.candles.empty()) {
             {
               std::lock_guard<std::mutex> lock_candles(
                   this->ctx_->candles_mutex);

--- a/src/core/kline_stream.cpp
+++ b/src/core/kline_stream.cpp
@@ -11,35 +11,41 @@
 namespace Core {
 
 KlineStream::KlineStream(const std::string &symbol, const std::string &interval,
-                         CandleManager &manager,
-                         WebSocketFactory ws_factory,
+                         CandleManager &manager, WebSocketFactory ws_factory,
                          SleepFunc sleep_func,
                          std::chrono::milliseconds base_delay)
     : symbol_(symbol), interval_(interval), candle_manager_(manager),
       ws_factory_(std::move(ws_factory)),
       sleep_func_(sleep_func ? std::move(sleep_func)
-                             : [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); }),
+                             : [](std::chrono::milliseconds
+                                      d) { std::this_thread::sleep_for(d); }),
       base_delay_(base_delay) {}
 
 KlineStream::~KlineStream() { stop(); }
 
-void KlineStream::start(CandleCallback cb, ErrorCallback err_cb) {
-  if (running_) return;
+void KlineStream::start(CandleCallback cb, ErrorCallback err_cb,
+                        UICallback ui_cb) {
+  if (running_)
+    return;
   running_ = true;
-  thread_ = std::thread(&KlineStream::run, this, cb, err_cb);
+  thread_ = std::thread(&KlineStream::run, this, cb, err_cb, ui_cb);
 }
 
 void KlineStream::stop() {
   running_ = false;
   {
     std::lock_guard<std::mutex> lock(ws_mutex_);
-    if (ws_) ws_->stop();
+    if (ws_)
+      ws_->stop();
   }
-  if (thread_.joinable()) thread_.join();
+  if (thread_.joinable())
+    thread_.join();
 }
 
-void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
-  const std::string url = "wss://stream.binance.com:9443/ws/" + symbol_ + "@kline_" + interval_;
+void KlineStream::run(CandleCallback cb, ErrorCallback err_cb,
+                      UICallback ui_cb) {
+  const std::string url =
+      "wss://stream.binance.com:9443/ws/" + symbol_ + "@kline_" + interval_;
   std::size_t attempt = 0;
 
   while (running_) {
@@ -48,8 +54,10 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
       ws_ = ws_factory_();
     }
     if (!ws_) {
-      Logger::instance().warn("WebSocket support not available; Kline streaming disabled");
-      if (err_cb) err_cb();
+      Logger::instance().warn(
+          "WebSocket support not available; Kline streaming disabled");
+      if (err_cb)
+        err_cb();
       running_ = false;
       break;
     }
@@ -60,7 +68,7 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
     bool closed = false;
 
     ws_->setUrl(url);
-    ws_->setOnMessage([this, cb](const std::string &msg) {
+    ws_->setOnMessage([this, cb, ui_cb](const std::string &msg) {
       try {
         auto j = nlohmann::json::parse(msg);
         if (j.contains("k")) {
@@ -68,20 +76,26 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
           bool closed = k.value("x", false);
           if (closed) {
             Candle c(
-                k.value("t", 0LL),
-                std::stod(k.value("o", std::string("0"))),
+                k.value("t", 0LL), std::stod(k.value("o", std::string("0"))),
                 std::stod(k.value("h", std::string("0"))),
                 std::stod(k.value("l", std::string("0"))),
                 std::stod(k.value("c", std::string("0"))),
-                std::stod(k.value("v", std::string("0"))),
-                k.value("T", 0LL),
-                std::stod(k.value("q", std::string("0"))),
-                k.value("n", 0),
+                std::stod(k.value("v", std::string("0"))), k.value("T", 0LL),
+                std::stod(k.value("q", std::string("0"))), k.value("n", 0),
                 std::stod(k.value("V", std::string("0"))),
-                std::stod(k.value("Q", std::string("0"))),
-                0.0);
+                std::stod(k.value("Q", std::string("0"))), 0.0);
             candle_manager_.append_candles(symbol_, interval_, {c});
-            if (cb) cb(c);
+            if (cb)
+              cb(c);
+            if (ui_cb) {
+              nlohmann::json out{{"time", c.open_time / 1000},
+                                 {"open", c.open},
+                                 {"high", c.high},
+                                 {"low", c.low},
+                                 {"close", c.close},
+                                 {"volume", c.volume}};
+              ui_cb(out.dump());
+            }
           }
         }
       } catch (const std::exception &e) {
@@ -91,7 +105,8 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
     ws_->setOnError([&]() {
       error = true;
       std::lock_guard<std::mutex> lock(ws_mutex_);
-      if (ws_) ws_->stop();
+      if (ws_)
+        ws_->stop();
     });
     ws_->setOnClose([&]() {
       {
@@ -116,9 +131,11 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
       }
     }
 
-    if (!running_) break;
+    if (!running_)
+      break;
 
-    if (error && err_cb) err_cb();
+    if (error && err_cb)
+      err_cb();
 
     if (error) {
       ++attempt;
@@ -131,4 +148,3 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb) {
 }
 
 } // namespace Core
-

--- a/src/core/kline_stream.h
+++ b/src/core/kline_stream.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <functional>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
-#include <chrono>
-#include <mutex>
-#include <memory>
 
 #include "candle.h"
 #include "candle_manager.h"
@@ -15,23 +15,26 @@
 namespace Core {
 class KlineStream {
 public:
-  using CandleCallback = std::function<void(const Candle&)>;
+  using CandleCallback = std::function<void(const Candle &)>;
   using ErrorCallback = std::function<void()>;
+  using UICallback = std::function<void(const std::string &)>;
   using SleepFunc = std::function<void(std::chrono::milliseconds)>;
 
-  KlineStream(const std::string &symbol, const std::string &interval,
-              CandleManager &manager,
-              WebSocketFactory ws_factory = default_websocket_factory(),
-              SleepFunc sleep_func = nullptr,
-              std::chrono::milliseconds base_delay = std::chrono::milliseconds(1000));
+  KlineStream(
+      const std::string &symbol, const std::string &interval,
+      CandleManager &manager,
+      WebSocketFactory ws_factory = default_websocket_factory(),
+      SleepFunc sleep_func = nullptr,
+      std::chrono::milliseconds base_delay = std::chrono::milliseconds(1000));
   ~KlineStream();
 
-  void start(CandleCallback cb, ErrorCallback err_cb = nullptr);
+  void start(CandleCallback cb, ErrorCallback err_cb = nullptr,
+             UICallback ui_cb = nullptr);
   void stop();
   bool running() const { return running_; }
 
 private:
-  void run(CandleCallback cb, ErrorCallback err_cb);
+  void run(CandleCallback cb, ErrorCallback err_cb, UICallback ui_cb);
 
   std::string symbol_;
   std::string interval_;
@@ -45,4 +48,3 @@ private:
   std::unique_ptr<IWebSocket> ws_;
 };
 } // namespace Core
-

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
-#include <string>
+#include <mutex>
 #include <optional>
-#include <chrono>
+#include <string>
 
 struct GLFWwindow;
 namespace webview {
@@ -29,6 +30,8 @@ public:
   void set_price_line(double price);
   // Sends a new candle to the chart for real-time updates.
   void push_candle(const Core::Candle &candle);
+  // Provides callback to forward candle JSON to the embedded chart.
+  std::function<void(const std::string &)> candle_callback();
   // Placeholder for future interval change notifications from embedded charts.
   void set_interval_callback(std::function<void(const std::string &)> cb);
   // Set callback for reporting status messages to the application.
@@ -45,6 +48,7 @@ private:
   std::function<void(const std::string &)> status_callback_;
   std::unique_ptr<webview::webview> chart_view_;
   bool shutdown_called_ = false;
+  mutable std::mutex ui_mutex_;
 
   // Throttling for real-time candle pushes
   std::chrono::steady_clock::time_point last_push_time_{};


### PR DESCRIPTION
## Summary
- Stream closed candles to UI callback in TradingView format with seconds timestamps
- Relay candle JSON to webview and update chart via new `updateCandle` JavaScript
- Guard webview access with mutex for thread safety

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a86d426f8c8327bbf32fa8cb3b9947