### PR TITLE
Handle missing Python in setup script

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -101,6 +101,8 @@ REM Ensure Python is available and install required packages
 where python >nul 2>nul
 if %errorlevel% neq 0 (
     echo Python not found. Please install Python and ensure it is in your PATH.
+    exit /b 1
+)
 echo Preparing chart resources...
 if not exist "%BUILD_DIR%\Debug" (
     mkdir "%BUILD_DIR%\Debug"


### PR DESCRIPTION
## Summary
- exit setup script with error if Python is not found
- close conditional block before preparing chart resources

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86fb49ef88327a35d2f9fd0388a54