### PR TITLE
Fix Python package installation error handling

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -123,6 +123,8 @@ if %errorlevel% neq 0 (
 python -m pip install requests pandas mplfinance
 if %errorlevel% neq 0 (
     echo Failed to install Python packages.
+    exit /b %errorlevel%
+)
 if not exist "%BUILD_DIR%\Release" (
     mkdir "%BUILD_DIR%\Release"
 )


### PR DESCRIPTION
## Summary
- exit on Python package installation failure in setup script
- ensure Release resource preparation runs outside error check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8707b62048327b8a66a84e91008b8