### PR TITLE
Add gtest to non-manifest vcpkg install

### DIFF
--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -64,7 +64,7 @@ if exist "%SCRIPT_DIR%vcpkg.json" (
     "%VCPKG_PATH%\vcpkg.exe" install --recurse --overlay-ports="%OVERLAY_PORTS%"
 ) else (
     echo Installing required packages...
-    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl --recurse --overlay-ports="%OVERLAY_PORTS%"
+    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl gtest --recurse --overlay-ports="%OVERLAY_PORTS%"
 )
 if %errorlevel% neq 0 (
     echo Dependency installation failed!


### PR DESCRIPTION
## Summary
- add gtest to vcpkg install line when no manifest is used

## Testing
- `wine cmd /c setup_and_build.bat` *(fails: winget is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8729c91c48327a4d4777e1816ab31