### PR TITLE
Add webview dependency and link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
   find_package(glfw3 CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
+  find_package(webview CONFIG REQUIRED)
 
   add_executable(TradingTerminal
     main.cpp
@@ -75,6 +76,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
       cpr::cpr
     glfw
     OpenGL::GL
+    webview::webview
   )
 
   target_include_directories(TradingTerminal PRIVATE

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "glfw3",
     "opengl",
     "gtest",
+    "webview",
     { "name": "webview2", "platform": "windows" }
   ]
 }


### PR DESCRIPTION
## Summary
- add webview to vcpkg dependencies
- locate and link webview in CMake build

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a87532e8b48327976a763f80294784