### PR TITLE
Include webview and candle headers in UiManager

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -9,9 +9,6 @@
 #include <optional>
 #include <sstream>
 
-#include "core/candle.h"
-#include <webview.h>
-
 #include "config_manager.h"
 #include "config_path.h"
 #include "core/logger.h"

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -7,13 +7,10 @@
 #include <optional>
 #include <string>
 
+#include <webview/webview.h>
+#include "core/candle.h"
+
 struct GLFWwindow;
-namespace webview {
-class webview;
-}
-namespace Core {
-struct Candle;
-}
 
 // Manages ImGui initialization and per-frame rendering and hosts auxiliary
 // UI panels. Currently only a placeholder chart panel is provided.

--- a/src/ui/webview_impl.cpp
+++ b/src/ui/webview_impl.cpp
@@ -1,2 +1,2 @@
 #define WEBVIEW_IMPLEMENTATION
-#include <webview.h>
+#include <webview/webview.h>


### PR DESCRIPTION
## Summary
- include webview/webview.h and core/candle.h directly in UiManager
- drop redundant includes and update webview implementation include path

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest")*


------
https://chatgpt.com/codex/tasks/task_e_68a876c5d85083279a8e547e359e885b