### PR TITLE
Include webview implementation in TradingTerminal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
       src/ui/analytics_window.cpp
       src/ui/journal_window.cpp
       src/ui/ui_manager.cpp
+    src/ui/webview_impl.cpp
   )
 
   target_sources(TradingTerminal PRIVATE


### PR DESCRIPTION
## Summary
- Add src/ui/webview_impl.cpp to TradingTerminal executable sources

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: webview/webview.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a87965be3c8327aa7159a2ae4f0534