### PR TITLE
Add vcpkg_common_functions include for webview port

### DIFF
--- a/ports/webview/portfile.cmake
+++ b/ports/webview/portfile.cmake
@@ -1,3 +1,5 @@
+include(vcpkg_common_functions)
+
 vcpkg_copy_sources(
     SOURCE_PATH "${CURRENT_PORT_DIR}"
     DESTINATION_PATH "${CURRENT_BUILDTREES_DIR}/src"


### PR DESCRIPTION
## Summary
- ensure webview port can use vcpkg helper macros by including `vcpkg_common_functions`

## Testing
- `./vcpkg install webview:x64-windows --overlay-ports=../ports --classic` *(fails: Use of Visual Studio's Developer Prompt is unsupported on non-Windows hosts)*


------
https://chatgpt.com/codex/tasks/task_e_68a87d63564c83279f84b8b78ed5fe4b