### PR TITLE
Fix webview portfile for latest vcpkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project follows [Semantic Versioning](https://semver.org/). Each entry list
 
 ### Errors and Fixes
 - ImGui optional docking/viewport flags (`ImGuiConfigFlags_DockingEnable`, `ImGuiConfigFlags_ViewportsEnable`) caused build errors with the vcpkg package. The flags and related calls were removed to restore successful compilation.
+- Overlay port `webview` failed to build due to deprecated `vcpkg_copy_sources`; replaced with direct `file(INSTALL ...)` commands.
 
 For every future change:
 1. Add a new version section with the format `## [x.y.z] - YYYY-MM-DD`.

--- a/ports/webview/portfile.cmake
+++ b/ports/webview/portfile.cmake
@@ -1,8 +1,2 @@
-include(vcpkg_common_functions)
-
-vcpkg_copy_sources(
-    SOURCE_PATH "${CURRENT_PORT_DIR}"
-    DESTINATION_PATH "${CURRENT_BUILDTREES_DIR}/src"
-)
-file(INSTALL "${CURRENT_PORT_DIR}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
-file(INSTALL "${CURRENT_PORT_DIR}/webviewConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/webview")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/webviewConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/webview")


### PR DESCRIPTION
## Summary
- Update webview overlay port to remove deprecated `vcpkg_copy_sources`
- Document webview port fix in changelog

## Testing
- `./vcpkg/vcpkg install --classic webview --overlay-ports=../ports`


------
https://chatgpt.com/codex/tasks/task_e_68a87e24228c832780489cb8868423a7