### PR TITLE
Run chart webview in background thread

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 
 #include <webview/webview.h>
 #include "core/candle.h"
@@ -19,8 +20,8 @@ public:
   ~UiManager();
   bool setup(GLFWwindow *window);
   void begin_frame();
-  // Draw docked panels each frame. Currently hosts a placeholder chart panel.
-  void draw_chart_panel(const std::string &selected_interval);
+  // Draw docked panels each frame.
+  void draw_chart_panel([[maybe_unused]] const std::string &selected_interval);
   // Pushes trade markers to the chart via series.setMarkers.
   void set_markers(const std::string &markers_json);
   // Draws/updates a price line for the currently open position.
@@ -44,6 +45,7 @@ private:
   std::function<void(const std::string &)> on_interval_changed_;
   std::function<void(const std::string &)> status_callback_;
   std::unique_ptr<webview::webview> chart_view_;
+  std::jthread chart_thread_;
   bool shutdown_called_ = false;
   mutable std::mutex ui_mutex_;
 


### PR DESCRIPTION
## Summary
- launch the chart webview on its own jthread
- clean up the webview thread during shutdown
- drop placeholder text from the chart panel

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_data_fetcher`
- `./build/test_backtester`
- `./build/test_candle_manager`
- `./build/test_signal`
- `./build/test_data_fetcher`
- `ctest --test-dir build` *(fails: Unable to find executable: /workspace/terminal_c/build/test_interval_utils)*

------
https://chatgpt.com/codex/tasks/task_e_68a893a10dc08327ae2690319411b5f2