### PR TITLE
feat: forward logger output to control panel

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -48,9 +48,10 @@ void App::WindowDeleter::operator()(GLFWwindow *window) const {
 App::App() : ctx_(std::make_unique<AppContext>()) {}
 App::~App() { cleanup(); }
 
-void App::add_status(const std::string &msg) {
+void App::add_status(const std::string &msg, Core::LogLevel level,
+                     std::chrono::system_clock::time_point time) {
   std::lock_guard<std::mutex> lock(status_mutex_);
-  status_.log.push_back(msg);
+  status_.log.push_back({time, level, msg});
   if (status_.log.size() > 50)
     status_.log.pop_front();
 }
@@ -104,6 +105,10 @@ void App::setup_imgui() {
       [this](const std::string &iv) { this->ctx_->selected_interval = iv; });
   ui_manager_.set_status_callback(
       [this](const std::string &msg) { this->add_status(msg); });
+  Core::Logger::instance().set_sink(
+      [this](Core::LogLevel level,
+             std::chrono::system_clock::time_point time,
+             const std::string &msg) { this->add_status(msg, level, time); });
 }
 
 void App::load_config() {

--- a/src/app.h
+++ b/src/app.h
@@ -17,6 +17,8 @@
 #include <thread>
 #include <vector>
 
+#include "core/logger.h"
+
 struct GLFWwindow;
 
 struct AppStatus {
@@ -24,7 +26,12 @@ struct AppStatus {
   std::string analysis_message = "Idle";
   std::string signal_message = "Idle";
   std::string error_message;
-  std::deque<std::string> log;
+  struct LogEntry {
+    std::chrono::system_clock::time_point time;
+    Core::LogLevel level;
+    std::string message;
+  };
+  std::deque<LogEntry> log;
 };
 
 // The App class owns the services and drives the main event loop.
@@ -35,7 +42,10 @@ public:
   // Runs the application. Returns the exit code.
   int run();
   const AppStatus &status() const { return status_; }
-  void add_status(const std::string &msg);
+  void add_status(const std::string &msg,
+                  Core::LogLevel level = Core::LogLevel::Info,
+                  std::chrono::system_clock::time_point time =
+                      std::chrono::system_clock::now());
   void clear_failed_fetches();
 
 private:

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include <functional>
 
 namespace Core {
 
@@ -19,6 +20,10 @@ public:
                 std::size_t max_size = 1024 * 1024);
   void enable_console_output(bool enable);
   void set_min_level(LogLevel level);
+  using Sink =
+      std::function<void(LogLevel, std::chrono::system_clock::time_point,
+                         const std::string &)>;
+  void set_sink(Sink sink);
   void log(LogLevel level, const std::string &message);
   void info(const std::string &message);
   void warn(const std::string &message);
@@ -46,6 +51,7 @@ private:
   std::string filename_;
   std::size_t max_file_size_ = 1024 * 1024;
   std::string level_to_string(LogLevel level);
+  Sink sink_;
 };
 
 } // namespace Core

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -271,8 +271,11 @@ bool DataService::reload_candles(const std::string &pair, const std::string &int
   auto res = fetch_klines(pair, interval, limit);
   if (res.error == Core::FetchError::None && !res.candles.empty()) {
     candle_manager_.save_candles(pair, interval, res.candles);
+    Core::Logger::instance().info("Reloaded " + pair + " " + interval);
     return true;
   }
+  Core::Logger::instance().error("Reload failed for " + pair + " " + interval +
+                                (res.message.empty() ? "" : ": " + res.message));
   return false;
 }
 

--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -75,10 +75,8 @@ void DrawSignalsWindow(
 
   if (need_recalc) {
     status.signal_message = "Computing signals";
-    status.log.push_back("Computing signals for " + active_pair + " " +
-                         selected_interval);
-    if (status.log.size() > 50)
-      status.log.pop_front();
+    Core::Logger::instance().info("Computing signals for " + active_pair +
+                                  " " + selected_interval);
     cache.strategy = strategy;
     cache.short_period = short_period;
     cache.long_period = long_period;


### PR DESCRIPTION
## Summary
- allow registering log sinks in Core::Logger
- surface logger messages in the UI with level, time and colors
- log data reload outcomes through the logger

## Testing
- `cmake .. && cmake --build . && ctest` *(fails: webview/webview.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8979aec808327a7b740ca5c2e311a