### PR TITLE
Simplify app to basic candle loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,15 +28,9 @@ if(NOT imgui_FOUND)
   target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui)
   add_library(imgui::imgui ALIAS imgui)
 endif()
-find_package(cpr CONFIG QUIET)
-if(NOT cpr_FOUND)
-  message(WARNING "cpr not found, skipping targets that require it")
-endif()
-
-if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
+if(BUILD_TRADING_TERMINAL)
   find_package(glfw3 CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
-  find_package(webview CONFIG REQUIRED)
 
   add_executable(TradingTerminal
     main.cpp
@@ -45,7 +39,6 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/config_schema.cpp
     src/config_path.cpp
       src/candle.cpp
-      src/signal.cpp
       src/core/candle_manager.cpp
     src/core/data_fetcher.cpp
     src/core/interval_utils.cpp
@@ -54,22 +47,14 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
     src/core/exchange_utils.cpp
     src/core/net/token_bucket_rate_limiter.cpp
     src/core/net/cpr_http_client.cpp
-    src/core/backtester.cpp
     src/core/kline_stream.cpp
     src/core/iwebsocket.cpp
     src/core/logger.cpp
     src/core/path_utils.cpp
     src/core/glfw_context.cpp
-    src/journal.cpp
     src/services/data_service.cpp
-    src/services/journal_service.cpp
-    src/services/signal_bot.cpp
     src/ui/control_panel.cpp
-    src/ui/signals_window.cpp
-      src/ui/analytics_window.cpp
-      src/ui/journal_window.cpp
-      src/ui/ui_manager.cpp
-    src/ui/webview_impl.cpp
+    src/ui/ui_manager.cpp
   )
 
   target_sources(TradingTerminal PRIVATE
@@ -79,10 +64,8 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
 
   target_link_libraries(TradingTerminal PRIVATE
       imgui::imgui
-      cpr::cpr
     glfw
     OpenGL::GL
-    webview::webview
   )
 
   target_include_directories(TradingTerminal PRIVATE
@@ -94,15 +77,6 @@ if(BUILD_TRADING_TERMINAL AND cpr_FOUND)
 endif()
 
 enable_testing()
-
-add_executable(test_backtester
-  tests/test_backtester.cpp
-  src/core/backtester.cpp
-  src/candle.cpp
-)
-target_include_directories(test_backtester PRIVATE src include)
-target_link_libraries(test_backtester PRIVATE GTest::gtest_main)
-add_test(NAME test_backtester COMMAND test_backtester)
 
 add_executable(test_candle_manager
   tests/test_candle_manager.cpp
@@ -117,21 +91,6 @@ add_executable(test_candle_manager
 target_include_directories(test_candle_manager PRIVATE src include)
 target_link_libraries(test_candle_manager PRIVATE GTest::gtest_main)
 add_test(NAME test_candle_manager COMMAND test_candle_manager)
-
-add_executable(test_signal
-  tests/test_signal.cpp
-  src/signal.cpp
-  src/candle.cpp
-  src/services/signal_bot.cpp
-  src/config_manager.cpp
-  src/config_schema.cpp
-  src/core/logger.cpp
-  src/config_path.cpp
-  src/core/path_utils.cpp
-)
-target_include_directories(test_signal PRIVATE src include)
-target_link_libraries(test_signal PRIVATE GTest::gtest_main)
-add_test(NAME test_signal COMMAND test_signal)
 
 add_executable(test_data_fetcher
   tests/test_data_fetcher.cpp
@@ -179,15 +138,6 @@ target_include_directories(test_kline_stream PRIVATE src include)
 target_link_libraries(test_kline_stream PRIVATE GTest::gtest_main)
 add_test(NAME test_kline_stream COMMAND test_kline_stream)
 
-add_executable(test_journal
-  tests/test_journal.cpp
-  src/journal.cpp
-  src/core/logger.cpp
-)
-target_include_directories(test_journal PRIVATE src include)
-target_link_libraries(test_journal PRIVATE GTest::gtest_main)
-add_test(NAME test_journal COMMAND test_journal)
-
   add_executable(test_logger
     tests/test_logger.cpp
     src/core/logger.cpp
@@ -198,6 +148,6 @@ add_test(NAME test_journal COMMAND test_journal)
 
 
   add_custom_target(ctest COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-      DEPENDS test_backtester test_candle_manager test_signal test_scheduler test_kline_stream test_data_fetcher test_interval_utils test_logger test_journal
+      DEPENDS test_candle_manager test_scheduler test_kline_stream test_data_fetcher test_interval_utils test_logger
     )
 

--- a/src/app.h
+++ b/src/app.h
@@ -2,7 +2,6 @@
 
 #include "app_context.h"
 #include "services/data_service.h"
-#include "services/journal_service.h"
 #include "ui/ui_manager.h"
 #include "core/glfw_context.h"
 
@@ -23,8 +22,6 @@ struct GLFWwindow;
 
 struct AppStatus {
   float candle_progress = 0.0f;
-  std::string analysis_message = "Idle";
-  std::string signal_message = "Idle";
   std::string error_message;
   struct LogEntry {
     std::chrono::system_clock::time_point time;
@@ -65,17 +62,14 @@ private:
                              long long now_ms);
   void handle_http_updates();
   void update_candle_progress();
-  void render_dockspace();
   void render_status_window();
   void render_main_windows();
-  void render_backtest_panel();
   void handle_active_pair_change();
   void start_fetch_thread();
   void stop_fetch_thread();
 
   std::unique_ptr<AppContext> ctx_;
   DataService data_service_;
-  JournalService journal_service_;
   AppStatus status_;
   mutable std::mutex status_mutex_;
   struct WindowDeleter {

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -13,20 +13,12 @@
 #include <set>
 #include <vector>
 
-#include "config_types.h"
-#include "core/backtester.h"
 #include "core/candle.h"
 #include "core/data_fetcher.h"
 #include "core/kline_stream.h"
 #include "ui/control_panel.h"
-#include "ui/signal_entry.h"
 
 struct AppContext {
-  struct TradeEvent {
-    double time;
-    double price;
-    enum class Side { Buy, Sell } side;
-  };
   std::vector<PairItem> pairs;
   std::vector<std::string> selected_pairs;
   std::string active_pair;
@@ -34,14 +26,6 @@ struct AppContext {
   std::vector<std::string> intervals;
   std::vector<std::string> exchange_pairs;
   std::string selected_interval;
-  std::string strategy = "sma_crossover";
-  int short_period = 9;
-  int long_period = 21;
-  double oversold = 30.0;
-  double overbought = 70.0;
-  bool show_on_chart = false;
-  std::vector<SignalEntry> signal_entries;
-  std::vector<TradeEvent> trades;
   std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>
       all_candles;
   std::mutex candles_mutex;
@@ -52,8 +36,6 @@ struct AppContext {
     std::future<Core::KlinesResult> future;
   };
   std::map<std::string, PendingFetch> pending_fetches;
-  Core::BacktestResult last_result;
-  Config::SignalConfig last_signal_cfg;
   struct FetchTask {
     std::string pair;
     std::string interval;

--- a/src/core/net/cpr_http_client.cpp
+++ b/src/core/net/cpr_http_client.cpp
@@ -1,15 +1,13 @@
 #include "cpr_http_client.h"
-#include <cpr/cpr.h>
 
 namespace Core {
 
 HttpResponse CprHttpClient::get(const std::string &url) {
-  cpr::Response r = cpr::Get(cpr::Url{url});
+  // Network functionality disabled in minimal build.
   HttpResponse resp;
-  resp.status_code = r.status_code;
-  resp.text = r.text;
-  resp.network_error = r.error.code != cpr::ErrorCode::OK;
-  resp.error_message = r.error.message;
+  resp.status_code = 0;
+  resp.network_error = true;
+  resp.error_message = "cpr unavailable";
   return resp;
 }
 

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -372,8 +372,6 @@ static void RenderStatusPane(AppStatus &status) {
   ImGui::Separator();
   ImGui::Text("Status");
   ImGui::Text("Candles: %.0f%%", status.candle_progress * 100.0f);
-  ImGui::Text("Analysis: %s", status.analysis_message.c_str());
-  ImGui::Text("Signals: %s", status.signal_message.c_str());
   if (!status.error_message.empty())
     ImGui::TextColored(COLOR_LOW, "%s", status.error_message.c_str());
   if (ImGui::BeginListBox("##status_log", ImVec2(-FLT_MIN, 100))) {

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -6,9 +6,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
-
-#include <webview/webview.h>
 #include "core/candle.h"
 
 struct GLFWwindow;
@@ -44,8 +41,6 @@ private:
   std::string current_interval_;
   std::function<void(const std::string &)> on_interval_changed_;
   std::function<void(const std::string &)> status_callback_;
-  std::unique_ptr<webview::webview> chart_view_;
-  std::jthread chart_thread_;
   bool shutdown_called_ = false;
   mutable std::mutex ui_mutex_;
 


### PR DESCRIPTION
## Summary
- drop analytics, journal, signal and other advanced modules
- strip App and context to minimal candle-loading pipeline
- stub out networking and chart components for lightweight build

## Testing
- `cmake --build . | tail -n 20`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68a978f246ac832789699086a3045380