### PR TITLE
Include system_error for errc usage

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <charconv>
 #include <string_view>
+#include <system_error>
 #include "core/logger.h"
 #include "interval_utils.h"
 #include "core/data_dir.h"

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <charconv>
 #include <fstream>
+#include <system_error>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string_view>


### PR DESCRIPTION
## Summary
- add missing `<system_error>` include to `journal.cpp` and `candle_manager.cpp`
- ensure `std::errc` usage compiles

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68aad0126d5483279dd0f18aa9137bf2