### PR TITLE
Guard webview include to compile without library

### DIFF
--- a/src/ui/webview_impl.cpp
+++ b/src/ui/webview_impl.cpp
@@ -1,2 +1,4 @@
+#if __has_include(<webview/webview.h>)
 #define WEBVIEW_IMPLEMENTATION
 #include <webview/webview.h>
+#endif


### PR DESCRIPTION
## Summary
- wrap webview implementation include in a `__has_include` guard

## Testing
- `g++ -std=c++20 -c src/ui/webview_impl.cpp`
- `g++ -std=c++20 -I/tmp -c src/ui/webview_impl.cpp`
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aad5deaa68832787a17aea47b8898c