### PR TITLE
Fix chart resources path for chart preparation script

### DIFF
--- a/scripts/prepare_chart_resources.bat
+++ b/scripts/prepare_chart_resources.bat
@@ -8,7 +8,7 @@ if "%~1"=="" (
 
 set "BUILD_DIR=%~1"
 
-set "SRC_DIR=%~dp0resources"
+set "SRC_DIR=%~dp0..\\resources"
 set "LC_FILE=lightweight-charts.standalone.production.js"
 
 if not exist "%SRC_DIR%\%LC_FILE%" (


### PR DESCRIPTION
## Summary
- adjust `prepare_chart_resources.bat` to look for resources in parent directory

## Testing
- manual file copy to confirm `chart.html` and `lightweight-charts.standalone.production.js` are available

------
https://chatgpt.com/codex/tasks/task_e_68aadae3748c8327b109a73eb4fa1239