### PR TITLE
fix build script path references

### DIFF
--- a/scripts/build_and_run.bat
+++ b/scripts/build_and_run.bat
@@ -1,8 +1,8 @@
 @echo off
 set PROJECT_DIR=%~dp0
-set BUILD_DIR=%PROJECT_DIR%\build
-set VCPKG_TOOLCHAIN_FILE=%PROJECT_DIR%vcpkg\scripts\buildsystems\vcpkg.cmake
-set VCPKG_OVERLAY_PORTS=%PROJECT_DIR%ports
+set BUILD_DIR=%PROJECT_DIR%..\build
+set VCPKG_TOOLCHAIN_FILE=%PROJECT_DIR%..\vcpkg\scripts\buildsystems\vcpkg.cmake
+set VCPKG_OVERLAY_PORTS=%PROJECT_DIR%..\ports
 
 echo Creating build directory if it doesn't exist...
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"


### PR DESCRIPTION
## Summary
- ensure Windows build script uses repository root for build directory and vcpkg paths

## Testing
- ⚠️ `cmd.exe /C scripts/build_and_run.bat` (command not found: cmd.exe)
- ⚠️ `wine cmd /c scripts/build_and_run.bat` (command not found: wine)


------
https://chatgpt.com/codex/tasks/task_e_68aadadae07483278cedcc3b7c56ed7f