### PR TITLE
Integrate WebView chart rendering into UI manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 if(BUILD_TRADING_TERMINAL)
   find_package(glfw3 CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
+  find_package(webview CONFIG QUIET)
 
   add_executable(TradingTerminal
     main.cpp
@@ -67,6 +68,10 @@ if(BUILD_TRADING_TERMINAL)
     glfw
     OpenGL::GL
   )
+  if(webview_FOUND)
+    target_link_libraries(TradingTerminal PRIVATE webview::webview)
+    target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
+  endif()
 
   target_include_directories(TradingTerminal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -8,6 +8,13 @@
 #include <string>
 #include "core/candle.h"
 
+#if __has_include(<webview/webview.h>)
+#include <thread>
+namespace webview {
+class webview;
+}
+#endif
+
 struct GLFWwindow;
 
 // Manages ImGui initialization and per-frame rendering and hosts auxiliary
@@ -48,4 +55,9 @@ private:
   std::chrono::steady_clock::time_point last_push_time_{};
   std::chrono::milliseconds throttle_interval_{100};
   std::optional<Core::Candle> cached_candle_{};
+
+#if __has_include(<webview/webview.h>)
+  std::unique_ptr<webview::webview> webview_;
+  std::thread webview_thread_;
+#endif
 };


### PR DESCRIPTION
## Summary
- Initialize a WebView in `UiManager` when enabled in config, loading `resources/chart.html`.
- Stream candles, price lines, and markers to the chart via JS bridge using thread-safe dispatch.
- Wire up CMake to optionally link the `webview` library.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aadb7c9cc48327803f4b6162f88d2e