### PR TITLE
Make webview optional and document fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 if(BUILD_TRADING_TERMINAL)
   find_package(glfw3 CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
-  find_package(webview CONFIG REQUIRED)
+  find_package(webview CONFIG QUIET)
 
   add_executable(TradingTerminal
     main.cpp
@@ -67,9 +67,16 @@ if(BUILD_TRADING_TERMINAL)
       imgui::imgui
     glfw
     OpenGL::GL
-    webview::webview
   )
-  target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
+
+  if(webview_FOUND)
+    target_link_libraries(TradingTerminal PRIVATE webview::webview)
+    target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
+  else()
+    message(WARNING "webview package not found; chart window will be disabled."
+                    " Provide src/ui/webview_impl.cpp for platform-specific implementations.")
+    # target_sources(TradingTerminal PRIVATE src/ui/webview_impl.cpp)
+  endif()
 
   target_include_directories(TradingTerminal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Standalone C++ trading terminal using ImGui. The project relies on packages prov
   - ImGui
   - CPR (встроен)
   - JSON (встроен)
-  - webview (встроен)
+  - webview (системный пакет; для платформ без него можно добавить собственную реализацию)
 - `CMakeLists.txt` использует `find_package()` для зависимостей через `vcpkg`
 
 ## Инструкция
@@ -30,6 +30,8 @@ Standalone C++ trading terminal using ImGui. The project relies on packages prov
 1. Установите [vcpkg](https://github.com/microsoft/vcpkg) и настройте переменную `CMAKE_TOOLCHAIN_FILE` на `scripts/buildsystems/vcpkg.cmake`.
    Опциональные зависимости:
    - `imgui` — используется из пакета, если он установлен; иначе проект собирает встроенные исходники из `third_party/imgui`.
+   - `webview` — используется из системного пакета; при его отсутствии можно реализовать `src/ui/webview_impl.cpp` и подключить
+     его в CMake только когда пакет недоступен.
 2. Выполните конфигурацию проекта:
    ```
    cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -48,6 +50,9 @@ The HTML file under `resources/` embeds [TradingView Lightweight Charts](https:/
 
 - **Windows:** requires the [Microsoft Edge WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
 - **Linux:** depends on WebKitGTK packages (`libwebkit2gtk-4.1-0` and related).
+
+If the `webview` package is not available, add a platform-specific implementation in `src/ui/webview_impl.cpp` and include it in
+CMake only when the system package cannot be found.
 
 ### TradingView script
 


### PR DESCRIPTION
## Summary
- Make webview a non-required dependency and link only when available
- Document how to provide a custom webview implementation when the system package is missing

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68aae42c2bf083278a9f569313eaeaa3