### PR TITLE
Use HAVE_WEBVIEW flag for optional WebView

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,18 +1,20 @@
 #pragma once
 
+#include "core/candle.h"
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include "core/candle.h"
 
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
 #include <thread>
 namespace webview {
 class webview;
 }
+#else
+// WebView library not available
 #endif
 
 struct GLFWwindow;
@@ -56,8 +58,10 @@ private:
   std::chrono::milliseconds throttle_interval_{100};
   std::optional<Core::Candle> cached_candle_{};
 
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
   std::unique_ptr<webview::webview> webview_;
   std::thread webview_thread_;
+#else
+  // No WebView support
 #endif
 };

--- a/src/ui/webview_impl.cpp
+++ b/src/ui/webview_impl.cpp
@@ -1,4 +1,6 @@
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
 #define WEBVIEW_IMPLEMENTATION
 #include <webview/webview.h>
+#else
+// WebView library not available
 #endif


### PR DESCRIPTION
## Summary
- Replace `__has_include` checks with `HAVE_WEBVIEW` in UI layer and provide stub fallbacks when WebView is absent.
- Ensure WebView implementation is only compiled when the library is available.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aae3f2e5e88327b77e21cc4120da07