### PR TITLE
Use HAVE_WEBVIEW flag for optional WebView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(BUILD_TRADING_TERMINAL)
   if(webview_FOUND)
     target_link_libraries(TradingTerminal PRIVATE webview::webview)
     target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
+    target_sources(TradingTerminal PRIVATE src/ui/webview_impl.cpp)
   endif()
 
   target_include_directories(TradingTerminal PRIVATE

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,18 +1,20 @@
 #pragma once
 
+#include "core/candle.h"
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include "core/candle.h"
 
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
 #include <thread>
 namespace webview {
 class webview;
 }
+#else
+// WebView library not available
 #endif
 
 struct GLFWwindow;
@@ -56,8 +58,10 @@ private:
   std::chrono::milliseconds throttle_interval_{100};
   std::optional<Core::Candle> cached_candle_{};
 
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
   std::unique_ptr<webview::webview> webview_;
   std::thread webview_thread_;
+#else
+  // No WebView support
 #endif
 };

--- a/src/ui/webview_impl.cpp
+++ b/src/ui/webview_impl.cpp
@@ -1,4 +1,6 @@
-#if __has_include(<webview/webview.h>)
+#ifdef HAVE_WEBVIEW
 #define WEBVIEW_IMPLEMENTATION
 #include <webview/webview.h>
+#else
+// WebView library not available
 #endif


### PR DESCRIPTION
## Summary
- Guard WebView code with `HAVE_WEBVIEW` and provide minimal fallbacks when the library is unavailable
- Compile WebView implementation only when the WebView package is found

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aae3f2e5e88327b77e21cc4120da07