### PR TITLE
Switch to header-only webview detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 if(BUILD_TRADING_TERMINAL)
   find_package(glfw3 CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
-  find_package(webview CONFIG QUIET)
 
   add_executable(TradingTerminal
     main.cpp
@@ -69,11 +68,27 @@ if(BUILD_TRADING_TERMINAL)
     OpenGL::GL
   )
 
-  if(webview_FOUND)
-    target_link_libraries(TradingTerminal PRIVATE webview::webview)
+  find_path(ZSERGE_WEBVIEW_INCLUDE_DIR "webview.h")
+  if (ZSERGE_WEBVIEW_INCLUDE_DIR)
+    target_include_directories(TradingTerminal PRIVATE ${ZSERGE_WEBVIEW_INCLUDE_DIR})
     target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
+    if (WIN32 AND TARGET WebView2LoaderStatic)
+      target_link_libraries(TradingTerminal PRIVATE WebView2LoaderStatic)
+    elseif(UNIX AND NOT APPLE)
+      find_package(PkgConfig QUIET)
+      if (PkgConfig_FOUND)
+        pkg_check_modules(WEBVIEWGTK QUIET gtk+-3.0 webkit2gtk-4.0)
+        if (WEBVIEWGTK_FOUND)
+          target_include_directories(TradingTerminal PRIVATE ${WEBVIEWGTK_INCLUDE_DIRS})
+          target_link_libraries(TradingTerminal PRIVATE ${WEBVIEWGTK_LIBRARIES})
+          target_compile_options(TradingTerminal PRIVATE ${WEBVIEWGTK_CFLAGS_OTHER})
+        else()
+          message(WARNING "gtk+-3.0 or webkit2gtk-4.0 not found; chart window will be disabled.")
+        endif()
+      endif()
+    endif()
   else()
-    message(WARNING "webview package not found; chart window will be disabled.")
+    message(WARNING "zserge-webview headers not found; chart window will be disabled.")
   endif()
 
   target_include_directories(TradingTerminal PRIVATE

--- a/scripts/setup_and_build.bat
+++ b/scripts/setup_and_build.bat
@@ -63,7 +63,7 @@ if exist "%SCRIPT_DIR%..\vcpkg.json" (
     "%VCPKG_PATH%\vcpkg.exe" install --recurse
 ) else (
     echo Installing required packages...
-    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl gtest webview webview2 --recurse
+    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl gtest zserge-webview webview2 --recurse
 )
 if %errorlevel% neq 0 (
     echo Dependency installation failed!

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
     "glfw3",
     "opengl",
     "gtest",
-    { "name": "webview", "version>=": "0.12.0" },
+    "zserge-webview",
     { "name": "webview2", "platform": "windows" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove `webview` CMake package and detect header-only zserge-webview
- link platform libraries for WebView only when header is found
- update vcpkg manifest and setup script to use `zserge-webview`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "GTest")*

------
https://chatgpt.com/codex/tasks/task_e_68aaedb87e10832793ab7a2c2829c28d