### PR TITLE
Include WebView header when available

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -10,9 +10,7 @@
 #include "core/candle.h"
 
 #ifdef HAVE_WEBVIEW
-namespace webview {
-class webview;
-}
+#include <webview.h>
 #else
 namespace webview {
 class webview {};


### PR DESCRIPTION
## Summary
- Include `<webview.h>` when WebView support is enabled
- Keep stub `webview` class for builds without WebView

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aaf3d279fc8327831689fb64068e53