### PR TITLE
Remove deprecated webview header include

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -9,11 +9,6 @@
 #include <optional>
 #include <sstream>
 #include <nlohmann/json.hpp>
-#ifdef HAVE_WEBVIEW
-#include <webview/webview.h>
-#else
-// WebView library not available; chart functionality will be disabled
-#endif
 
 #include "config_manager.h"
 #include "config_path.h"

--- a/third_party/webview_legacy/webview.h
+++ b/third_party/webview_legacy/webview.h
@@ -1,15 +1,14 @@
 /**
  * @file webview.h
  *
- * @deprecated This header file is deprecated. Use `webview/webview.h` instead.
+ * @deprecated This compatibility header is deprecated. Include `<webview.h>`
+ * directly instead.
  *
- * This file is provided for backward-compatibility with existing code
- * such as `#include "webview.h"`.
+ * This file is retained for backward-compatibility with existing code such as
+ * `#include "webview.h"` but intentionally contains no implementation.
  */
 
 #ifndef WEBVIEW_ROOT_H
 #define WEBVIEW_ROOT_H
-
-#include "webview/webview.h"
 
 #endif // WEBVIEW_ROOT_H


### PR DESCRIPTION
## Summary
- drop direct inclusion of `webview/webview.h` from the UI manager
- clean up legacy `webview.h` shim that referenced the old path

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68aaf4fbab648327b3f13c9c5836bc5f