### PR TITLE
Remove zserge-webview dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,9 @@ if(BUILD_TRADING_TERMINAL)
     OpenGL::GL
   )
 
-  find_path(ZSERGE_WEBVIEW_INCLUDE_DIR "webview.h")
-  if (ZSERGE_WEBVIEW_INCLUDE_DIR)
-    target_include_directories(TradingTerminal PRIVATE ${ZSERGE_WEBVIEW_INCLUDE_DIR})
+  find_path(WEBVIEW_INCLUDE_DIR "webview.h")
+  if (WEBVIEW_INCLUDE_DIR)
+    target_include_directories(TradingTerminal PRIVATE ${WEBVIEW_INCLUDE_DIR})
     target_compile_definitions(TradingTerminal PRIVATE HAVE_WEBVIEW)
     if (WIN32 AND TARGET WebView2LoaderStatic)
       target_link_libraries(TradingTerminal PRIVATE WebView2LoaderStatic)
@@ -88,7 +88,7 @@ if(BUILD_TRADING_TERMINAL)
       endif()
     endif()
   else()
-    message(WARNING "zserge-webview headers not found; chart window will be disabled.")
+    message(WARNING "webview headers not found; chart window will be disabled.")
   endif()
 
   target_include_directories(TradingTerminal PRIVATE

--- a/scripts/setup_and_build.bat
+++ b/scripts/setup_and_build.bat
@@ -63,7 +63,7 @@ if exist "%SCRIPT_DIR%..\vcpkg.json" (
     "%VCPKG_PATH%\vcpkg.exe" install --recurse
 ) else (
     echo Installing required packages...
-    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl gtest zserge-webview webview2 --recurse
+    "%VCPKG_PATH%\vcpkg.exe" install imgui[core,docking-experimental,glfw-binding,opengl3-binding] cpr nlohmann-json arrow glfw3 opengl gtest webview2 --recurse
 )
 if %errorlevel% neq 0 (
     echo Dependency installation failed!

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,6 @@
     "glfw3",
     "opengl",
     "gtest",
-    "zserge-webview",
     { "name": "webview2", "platform": "windows" }
   ]
 }


### PR DESCRIPTION
## Summary
- drop zserge-webview from vcpkg manifest and setup script
- update build configuration to handle generic webview headers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest"...)*

------
https://chatgpt.com/codex/tasks/task_e_68aafc6f867c83279147b528e6b18046