### PR TITLE
Remove outdated WebView stubs

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -11,10 +11,6 @@
 
 #ifdef HAVE_WEBVIEW
 #include <webview.h>
-#else
-namespace webview {
-class webview {};
-}
 #endif
 
 struct GLFWwindow;


### PR DESCRIPTION
## Summary
- clean up `UiManager` WebView header logic by removing old stub namespace

## Testing
- `cmake ..`
- `cmake --build .` *(fails: `gtk/gtk.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68aafeaabe4483278fefb6e8fc5fc4da