### PR TITLE
Embed webview into GLFW window

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -6,7 +6,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include "core/candle.h"
 
 #ifdef HAVE_WEBVIEW
@@ -56,7 +55,6 @@ private:
 
 #ifdef HAVE_WEBVIEW
   std::unique_ptr<webview::webview> webview_;
-  std::thread webview_thread_;
 #else
   // WebView is unavailable; members omitted
 #endif


### PR DESCRIPTION
## Summary
- Pass GLFW native window handle to `webview::webview` so the chart embeds in the main window
- Remove background webview thread and run WebView within main loop
- Render WebView inside ImGui chart panel and resize/move it to match panel size

## Testing
- `cmake ..` *(fails: gtk+-3.0 or webkit2gtk-4.0 not found)*
- `cmake --build .` *(fails: fatal error: gtk/gtk.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab071f733883279ea67e56f06a6055