### PR TITLE
Refactor candlestick plotting for ImPlot v0.16

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -43,30 +44,35 @@ void PlotCandlestick(const char *label_id, const double *xs, const double *opens
                      float width_percent = 0.25f,
                      ImVec4 bullCol = ImVec4(0, 1, 0, 1),
                      ImVec4 bearCol = ImVec4(1, 0, 0, 1)) {
+  (void)label_id;
   ImDrawList *draw_list = ImPlot::GetPlotDrawList();
   double half_width =
       count > 1 ? (xs[1] - xs[0]) * width_percent : width_percent;
 
   if (ImPlot::IsPlotHovered() && tooltip) {
     ImPlotPoint mouse = ImPlot::GetPlotMousePos();
-    mouse.x = ImPlot::RoundTime(ImPlotTime::FromDouble(mouse.x),
-                                ImPlotTimeUnit_Day)
-                  .ToDouble();
-    float tool_l = ImPlot::PlotToPixels(mouse.x - half_width * 1.5, mouse.y).x;
-    float tool_r = ImPlot::PlotToPixels(mouse.x + half_width * 1.5, mouse.y).x;
+    double rounded_x = std::round(mouse.x);
+    float tool_l =
+        ImPlot::PlotToPixels(rounded_x - half_width * 1.5, mouse.y).x;
+    float tool_r =
+        ImPlot::PlotToPixels(rounded_x + half_width * 1.5, mouse.y).x;
     float tool_t = ImPlot::GetPlotPos().y;
     float tool_b = tool_t + ImPlot::GetPlotSize().y;
     ImPlot::PushPlotClipRect();
     draw_list->AddRectFilled(ImVec2(tool_l, tool_t), ImVec2(tool_r, tool_b),
                              IM_COL32(128, 128, 128, 64));
     ImPlot::PopPlotClipRect();
-    int idx = BinarySearch(xs, 0, count - 1, mouse.x);
+    int idx = BinarySearch(xs, 0, count - 1, rounded_x);
     if (idx != -1) {
       ImGui::BeginTooltip();
-      char buff[32];
-      ImPlot::FormatDate(ImPlotTime::FromDouble(xs[idx]), buff, 32,
-                         ImPlotDateFmt_DayMoYr, ImPlot::GetStyle().UseISO8601);
-      ImGui::Text("Day:   %s", buff);
+      auto tp =
+          std::chrono::system_clock::time_point(
+              std::chrono::seconds(static_cast<long long>(xs[idx])));
+      std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+      std::tm tm = *std::gmtime(&tt);
+      std::ostringstream oss;
+      oss << std::put_time(&tm, "%Y-%m-%d");
+      ImGui::Text("Day:   %s", oss.str().c_str());
       ImGui::Text("Open:  $%.2f", opens[idx]);
       ImGui::Text("Close: $%.2f", closes[idx]);
       ImGui::Text("Low:   $%.2f", lows[idx]);
@@ -75,25 +81,15 @@ void PlotCandlestick(const char *label_id, const double *xs, const double *opens
     }
   }
 
-  if (ImPlot::BeginItem(label_id)) {
-    ImPlot::GetCurrentItem()->Color = IM_COL32(64, 64, 64, 255);
-    if (ImPlot::FitThisFrame()) {
-      for (int i = 0; i < count; ++i) {
-        ImPlot::FitPoint(ImPlotPoint(xs[i], lows[i]));
-        ImPlot::FitPoint(ImPlotPoint(xs[i], highs[i]));
-      }
-    }
-    for (int i = 0; i < count; ++i) {
-      ImVec2 open_pos = ImPlot::PlotToPixels(xs[i] - half_width, opens[i]);
-      ImVec2 close_pos = ImPlot::PlotToPixels(xs[i] + half_width, closes[i]);
-      ImVec2 low_pos = ImPlot::PlotToPixels(xs[i], lows[i]);
-      ImVec2 high_pos = ImPlot::PlotToPixels(xs[i], highs[i]);
-      ImU32 color =
-          ImGui::GetColorU32(opens[i] > closes[i] ? bearCol : bullCol);
-      draw_list->AddLine(low_pos, high_pos, color);
-      draw_list->AddRectFilled(open_pos, close_pos, color);
-    }
-    ImPlot::EndItem();
+  for (int i = 0; i < count; ++i) {
+    ImVec2 open_pos = ImPlot::PlotToPixels(xs[i] - half_width, opens[i]);
+    ImVec2 close_pos = ImPlot::PlotToPixels(xs[i] + half_width, closes[i]);
+    ImVec2 low_pos = ImPlot::PlotToPixels(xs[i], lows[i]);
+    ImVec2 high_pos = ImPlot::PlotToPixels(xs[i], highs[i]);
+    ImU32 color =
+        ImGui::GetColorU32(opens[i] > closes[i] ? bearCol : bullCol);
+    draw_list->AddLine(low_pos, high_pos, color);
+    draw_list->AddRectFilled(open_pos, close_pos, color);
   }
 }
 
@@ -201,6 +197,8 @@ void UiManager::draw_chart_panel(const std::string &selected_interval) {
     }
   }
   if (ImPlot::BeginPlot("Candles", ImVec2(-1, -1))) {
+    ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+    ImPlot::SetupAxisFormat(ImAxis_X1, "%Y-%m-%d");
     if (!xs.empty()) {
       PlotCandlestick("price", xs.data(), opens.data(), closes.data(),
                       lows.data(), highs.data(), (int)xs.size());


### PR DESCRIPTION
## Summary
- Rework candlestick renderer to drop deprecated ImPlot APIs and draw primitives directly
- Configure X axis for time and use chrono/put_time for tooltip dates

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF -DCMAKE_CXX_FLAGS=-I/workspace/terminal_c/third_party/imgui`
- `cmake --build build`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ab23e1725c8327a5e6f83b562260cb