### PR TITLE
Add method to set candles and wire up App

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -599,6 +599,7 @@ void App::handle_active_pair_change() {
       if (candles.empty())
         candles = data_service_.load_candles(this->ctx_->active_pair,
                                              this->ctx_->active_interval);
+      ui_manager_.set_candles(candles);
       miss = this->ctx_->candles_limit - static_cast<int>(candles.size());
     }
     bool exists;

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -274,6 +274,14 @@ std::function<void(const std::string &)> UiManager::candle_callback() {
   };
 }
 
+void UiManager::set_candles(const std::vector<Core::Candle> &candles) {
+  std::lock_guard<std::mutex> lock(ui_mutex_);
+  candles_.clear();
+  candles_.reserve(candles.size());
+  candles_.insert(candles_.end(), candles.begin(), candles.end());
+  cached_candle_.reset();
+}
+
 void UiManager::push_candle(const Core::Candle &candle) {
   std::lock_guard<std::mutex> lock(ui_mutex_);
   auto now = std::chrono::steady_clock::now();

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -25,6 +25,8 @@ public:
   void set_markers(const std::string &markers_json);
   // Draws/updates a price line for the currently open position.
   void set_price_line(double price);
+  // Replaces all chart candles with the provided collection.
+  void set_candles(const std::vector<Core::Candle> &candles);
   // Sends a new candle to the chart for real-time updates.
   void push_candle(const Core::Candle &candle);
   // Provides callback to forward candle JSON to the chart.


### PR DESCRIPTION
## Summary
- add `UiManager::set_candles` to reset candles collection
- update `App::handle_active_pair_change` to synchronize UI candles

## Testing
- `cmake -S . -B build -DCMAKE_PREFIX_PATH=/usr/local` *(fails: missing `CURL::libcurl_shared` target)*

------
https://chatgpt.com/codex/tasks/task_e_68ab38a447ac83279f75d62eabe3f854