### PR TITLE
Add pair and interval selectors to chart panel

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -95,13 +95,16 @@ bool App::init_window() {
 
 void App::setup_imgui() {
   ui_manager_.setup(window_.get());
-  ui_manager_.set_interval_callback(
-      [this](const std::string &iv) { this->ctx_->selected_interval = iv; });
+  ui_manager_.set_interval_callback([this](const std::string &iv) {
+    this->ctx_->selected_interval = iv;
+    this->ctx_->active_interval = iv;
+  });
+  ui_manager_.set_pair_callback(
+      [this](const std::string &p) { this->ctx_->active_pair = p; });
   ui_manager_.set_status_callback(
       [this](const std::string &msg) { this->add_status(msg); });
   Core::Logger::instance().set_sink(
-      [this](Core::LogLevel level,
-             std::chrono::system_clock::time_point time,
+      [this](Core::LogLevel level, std::chrono::system_clock::time_point time,
              const std::string &msg) { this->add_status(msg, level, time); });
 }
 
@@ -180,6 +183,7 @@ void App::load_pairs(std::vector<std::string> &pair_names) {
   this->ctx_->selected_interval =
       this->ctx_->intervals.empty() ? "1m" : this->ctx_->intervals[0];
   ui_manager_.set_initial_interval(this->ctx_->selected_interval);
+  ui_manager_.set_initial_pair(this->ctx_->active_pair);
 }
 
 void App::load_existing_candles() {
@@ -583,7 +587,8 @@ void App::render_main_windows() {
                    this->ctx_->selected_interval, this->ctx_->all_candles,
                    this->ctx_->save_pairs, this->ctx_->exchange_pairs, status_,
                    data_service_, this->ctx_->cancel_pair);
-  ui_manager_.draw_chart_panel(this->ctx_->selected_interval);
+  ui_manager_.draw_chart_panel(this->ctx_->selected_pairs,
+                               this->ctx_->intervals);
 }
 
 void App::handle_active_pair_change() {

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/candle.h"
+#include "imgui.h"
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -7,8 +9,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-#include "imgui.h"
-#include "core/candle.h"
 
 struct GLFWwindow;
 
@@ -20,7 +20,8 @@ public:
   bool setup(GLFWwindow *window);
   void begin_frame();
   // Draw docked panels each frame.
-  void draw_chart_panel(const std::string &selected_interval);
+  void draw_chart_panel(const std::vector<std::string> &pairs,
+                        const std::vector<std::string> &intervals);
   // Pushes trade markers to the chart.
   void set_markers(const std::string &markers_json);
   // Draws/updates a price line for the currently open position.
@@ -33,10 +34,14 @@ public:
   std::function<void(const std::string &)> candle_callback();
   // Placeholder for future interval change notifications from embedded charts.
   void set_interval_callback(std::function<void(const std::string &)> cb);
+  // Notify when the active trading pair changes.
+  void set_pair_callback(std::function<void(const std::string &)> cb);
   // Set callback for reporting status messages to the application.
   void set_status_callback(std::function<void(const std::string &)> cb);
   // Inform the UI about the current interval during initialization.
   void set_initial_interval(const std::string &interval);
+  // Inform the UI about the current pair during initialization.
+  void set_initial_pair(const std::string &pair);
   void end_frame(GLFWwindow *window);
   void shutdown();
 
@@ -51,7 +56,9 @@ private:
   std::vector<Marker> markers_;
   std::optional<double> price_line_;
   std::string current_interval_;
+  std::string current_pair_;
   std::function<void(const std::string &)> on_interval_changed_;
+  std::function<void(const std::string &)> on_pair_changed_;
   std::function<void(const std::string &)> status_callback_;
   bool shutdown_called_ = false;
   mutable std::mutex ui_mutex_;


### PR DESCRIPTION
## Summary
- Add pair and interval combo boxes to chart panel
- Notify application when pair or interval changes via new callbacks
- Initialize UI with current pair and interval selections

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ab42bb5b0083278a0e4b37294e83ed