### PR TITLE
Integrate WebView chart

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <string>
 #include <vector>
 
@@ -82,4 +83,10 @@ private:
   std::chrono::steady_clock::time_point last_push_time_{};
   std::chrono::milliseconds throttle_interval_{100};
   std::optional<Core::Candle> cached_candle_{};
+
+#ifdef HAVE_WEBVIEW
+  void *webview_ = nullptr;
+  std::jthread webview_thread_{};
+  bool webview_ready_ = false;
+#endif
 };


### PR DESCRIPTION
## Summary
- Initialize and manage WebView instance to display chart in external window with callbacks for interval, pair and status.
- Forward marker and price-line updates to the browser and serialize candles to JSON for initial data.
- Push real-time candles to the chart via `updateCandle`.

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4dc6b0848327b5c90c3be3b02fad