### PR TITLE
Add localization options to chart creation

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -5,7 +5,15 @@
 <div id="tvchart" style="width:100%;height:100%;"></div>
 <script src="lightweight-charts.standalone.production.js"></script>
 <script>
-  const chart = LightweightCharts.createChart(document.getElementById('tvchart'), {width:600, height:300});
+    const chart = LightweightCharts.createChart(
+      document.getElementById('tvchart'),
+      {
+        width: 600,
+        height: 300,
+        localization: { locale: 'ru-RU' },
+        timeScale: { timeVisible: true, secondsVisible: false }
+      }
+    );
   const series = chart.addCandlestickSeries();
   const data = [];
   window.updateCandle = function(c) {

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -322,7 +322,7 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
   }
   if (ImPlot::BeginPlot("Candles", ImVec2(-1, -1))) {
     ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
-    ImPlot::SetupAxisFormat(ImAxis_X1, "%Y-%m-%d");
+    ImPlot::SetupAxisFormat(ImAxis_X1, "%Y-%m-%d %H:%M");
     if (!xs.empty()) {
       PlotCandlestick("price", xs.data(), opens.data(), closes.data(),
                       lows.data(), highs.data(), (int)xs.size());


### PR DESCRIPTION
## Summary
- localize TradingView chart to Russian locale and show minutes-only time scale
- format ImPlot fallback axis for date/time and set time scale

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*


------
https://chatgpt.com/codex/tasks/task_e_68ab5117bd648327bd9f72173a9456c9