### PR TITLE
Add crosshair overlays and coordinate tracking

### DIFF
--- a/resources/chart.html
+++ b/resources/chart.html
@@ -11,6 +11,7 @@
     #toolbar button { width:48px; }
     #toolbar button.active { background:#555; }
     #overlay { position:absolute; left:0; top:0; z-index:5; }
+    #coords { position:absolute; right:0; bottom:0; z-index:10; background:#222; color:#fff; padding:2px 4px; font-family:monospace; }
   </style>
 </head>
 <body>
@@ -30,12 +31,14 @@
   </div>
   <div id="tvchart"></div>
   <canvas id="overlay"></canvas>
+  <div id="coords"></div>
 </div>
 <script src="lightweight-charts.standalone.production.js"></script>
 <script>
   const container = document.getElementById('container');
   const chartEl = document.getElementById('tvchart');
   const overlay = document.getElementById('overlay');
+  const coordsEl = document.getElementById('coords');
 
   const chart = LightweightCharts.createChart(chartEl, {
     width: container.clientWidth,
@@ -48,6 +51,21 @@
   let priceLine = null;
   const data = [];
   const ctx = overlay.getContext('2d');
+  chart.subscribeCrosshairMove(param => {
+    if (!param.time || !param.point) {
+      coordsEl.textContent = '';
+      return;
+    }
+    const price = param.seriesPrices.get(series);
+    let timeStr = '';
+    if (typeof param.time === 'object') {
+      timeStr = `${param.time.year}-${param.time.month}-${param.time.day}`;
+    } else {
+      const d = new Date(param.time * 1000);
+      timeStr = d.toLocaleString();
+    }
+    coordsEl.textContent = `${timeStr} ${price !== undefined ? price.toFixed(2) : ''}`;
+  });
 
   function resize() {
     const w = container.clientWidth;

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -481,6 +481,30 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
       double x_max = xs.back();
       ImPlotPoint mouse = ImPlot::GetPlotMousePos();
       if (ImPlot::IsPlotHovered()) {
+        if (current_tool_ == DrawTool::None) {
+          ImPlotRect lims = ImPlot::GetPlotLimits();
+          ImDrawList *dl = ImPlot::GetPlotDrawList();
+          ImVec2 top = ImPlot::PlotToPixels(mouse.x, lims.Y.Max);
+          ImVec2 bottom = ImPlot::PlotToPixels(mouse.x, lims.Y.Min);
+          ImVec2 left = ImPlot::PlotToPixels(lims.X.Min, mouse.y);
+          ImVec2 right = ImPlot::PlotToPixels(lims.X.Max, mouse.y);
+          ImPlot::PushPlotClipRect();
+          dl->AddLine(top, bottom, IM_COL32(128, 128, 128, 128));
+          dl->AddLine(left, right, IM_COL32(128, 128, 128, 128));
+          ImPlot::PopPlotClipRect();
+          char price_buf[32];
+          std::snprintf(price_buf, sizeof(price_buf), "%.2f", mouse.y);
+          ImPlot::Annotation(lims.X.Max, mouse.y, ImVec4(1, 1, 1, 1),
+                             ImVec2(5, 0), true, price_buf);
+          auto tp = std::chrono::system_clock::time_point(
+              std::chrono::seconds(static_cast<long long>(mouse.x)));
+          std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+          std::tm tm = *std::gmtime(&tt);
+          char time_buf[32];
+          std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M", &tm);
+          ImPlot::Annotation(mouse.x, lims.Y.Min, ImVec4(1, 1, 1, 1),
+                             ImVec2(0, 5), true, time_buf);
+        }
         if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
           if (editing_object_ >= 0) {
             auto &obj = draw_objects_[editing_object_];


### PR DESCRIPTION
## Summary
- Draw crosshair lines in fallback chart when no drawing tool is active and show price/time via annotations
- Display crosshair coordinates in web chart using subscribeCrosshairMove

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: test_kline_stream subprocess aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64b63e248327989c2d354aa9258a