### PR TITLE
Handle missing analytics data gracefully

### DIFF
--- a/src/ui/analytics_window.cpp
+++ b/src/ui/analytics_window.cpp
@@ -5,23 +5,27 @@
 #include <algorithm>
 #include <vector>
 
-
 void DrawAnalyticsWindow(
-    const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
-    const std::string& active_pair,
-    const std::string& selected_interval) {
-    ImGui::Begin("Analytics");
-    const auto& ana_candles = all_candles.at(active_pair).at(selected_interval);
-    if (!ana_candles.empty()) {
+    const std::map<std::string,
+                   std::map<std::string, std::vector<Core::Candle>>>
+        &all_candles,
+    const std::string &active_pair, const std::string &selected_interval) {
+  ImGui::Begin("Analytics");
+  auto pair_it = all_candles.find(active_pair);
+  if (pair_it != all_candles.end()) {
+    auto interval_it = pair_it->second.find(selected_interval);
+    if (interval_it != pair_it->second.end()) {
+      const auto &ana_candles = interval_it->second;
+      if (!ana_candles.empty()) {
         double min_price = ana_candles.front().low;
         double max_price = ana_candles.front().high;
         double sum_volume = 0.0;
         double sum_close = 0.0;
-        for (const auto& c : ana_candles) {
-            min_price = std::min(min_price, c.low);
-            max_price = std::max(max_price, c.high);
-            sum_volume += c.volume;
-            sum_close += c.close;
+        for (const auto &c : ana_candles) {
+          min_price = std::min(min_price, c.low);
+          max_price = std::max(max_price, c.high);
+          sum_volume += c.volume;
+          sum_close += c.close;
         }
         double avg_volume = sum_volume / ana_candles.size();
         double avg_close = sum_close / ana_candles.size();
@@ -31,24 +35,29 @@ void DrawAnalyticsWindow(
                                 : 0.0;
 
         if (ImGui::BeginTabBar("##analytics_tabs")) {
-            if (ImGui::BeginTabItem("Price")) {
-                ImGui::Text("Data points: %d", (int)ana_candles.size());
-                ImGui::Text("Min price: %.2f", min_price);
-                ImGui::Text("Max price: %.2f", max_price);
-                ImGui::Text("Avg close: %.2f", avg_close);
-                ImGui::Text("Change: %.2f (%.2f%%)", change, change_pct);
-                ImGui::EndTabItem();
-            }
+          if (ImGui::BeginTabItem("Price")) {
+            ImGui::Text("Data points: %d", (int)ana_candles.size());
+            ImGui::Text("Min price: %.2f", min_price);
+            ImGui::Text("Max price: %.2f", max_price);
+            ImGui::Text("Avg close: %.2f", avg_close);
+            ImGui::Text("Change: %.2f (%.2f%%)", change, change_pct);
+            ImGui::EndTabItem();
+          }
 
-            if (ImGui::BeginTabItem("Volume")) {
-                ImGui::Text("Avg volume: %.2f", avg_volume);
-                ImGui::EndTabItem();
-            }
-            ImGui::EndTabBar();
+          if (ImGui::BeginTabItem("Volume")) {
+            ImGui::Text("Avg volume: %.2f", avg_volume);
+            ImGui::EndTabItem();
+          }
+          ImGui::EndTabBar();
         }
-    } else {
+      } else {
         ImGui::Text("No data");
+      }
+    } else {
+      ImGui::Text("Information unavailable");
     }
-    ImGui::End();
+  } else {
+    ImGui::Text("Information unavailable");
+  }
+  ImGui::End();
 }
-


### PR DESCRIPTION
## Summary
- Avoid at() lookups for missing trading pairs or intervals in analytics window
- Show "Information unavailable" when data is missing instead of crashing

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ab74490ac883279d19ee6622a1d69d