### PR TITLE
Add analytics window toggle and rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ if(BUILD_TRADING_TERMINAL)
     src/core/glfw_context.cpp
     src/services/data_service.cpp
     src/ui/control_panel.cpp
+    src/ui/analytics_window.cpp
     src/ui/ui_manager.cpp
   )
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -29,6 +29,7 @@
 #include <GLFW/glfw3.h>
 
 #include "ui/control_panel.h"
+#include "ui/analytics_window.h"
 
 static void OnFramebufferResize(GLFWwindow * /*w*/, int width, int height) {
   glViewport(0, 0, width, height);
@@ -586,9 +587,14 @@ void App::render_main_windows() {
                    this->ctx_->active_pair, this->ctx_->intervals,
                    this->ctx_->selected_interval, this->ctx_->all_candles,
                    this->ctx_->save_pairs, this->ctx_->exchange_pairs, status_,
-                   data_service_, this->ctx_->cancel_pair);
+                   data_service_, this->ctx_->cancel_pair,
+                   this->ctx_->show_analytics_window);
   ui_manager_.draw_chart_panel(this->ctx_->selected_pairs,
                                this->ctx_->intervals);
+  if (this->ctx_->show_analytics_window) {
+    DrawAnalyticsWindow(this->ctx_->all_candles, this->ctx_->active_pair,
+                        this->ctx_->selected_interval);
+  }
 }
 
 void App::handle_active_pair_change() {

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -56,6 +56,7 @@ struct AppContext {
   std::function<void(const std::string &)> cancel_pair;
   std::string last_active_pair;
   std::string last_active_interval;
+  bool show_analytics_window = false;
   std::chrono::milliseconds retry_delay{5000};
   int max_retries = 3;
   bool exponential_backoff = true;

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -413,7 +413,8 @@ void DrawControlPanel(
     const std::function<void()> &save_pairs,
     const std::vector<std::string> &exchange_pairs, AppStatus &status,
     DataService &data_service,
-    const std::function<void(const std::string &)> &cancel_pair) {
+    const std::function<void(const std::string &)> &cancel_pair,
+    bool &show_analytics_window) {
   ImGui::Begin("Control Panel");
 
   RenderLoadControls(pairs, selected_pairs, intervals, all_candles, save_pairs,
@@ -422,6 +423,9 @@ void DrawControlPanel(
                      selected_interval, all_candles, save_pairs, data_service,
                      status, cancel_pair);
   RenderStatusPane(status);
+
+  ImGui::Separator();
+  ImGui::Checkbox("Analytics", &show_analytics_window);
 
   ImGui::End();
 }

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -26,5 +26,6 @@ void DrawControlPanel(
     const std::vector<std::string>& exchange_pairs,
     AppStatus& status,
     DataService& data_service,
-    const std::function<void(const std::string&)>& cancel_pair);
+    const std::function<void(const std::string&)>& cancel_pair,
+    bool& show_analytics_window);
 


### PR DESCRIPTION
## Summary
- Render new Analytics window from `App::render_main_windows` when enabled.
- Add checkbox in Control Panel to toggle Analytics display.
- Wire build system and context to support Analytics window.

## Testing
- `cmake ..` (fails: Could not find a package configuration file provided by "cpr")


------
https://chatgpt.com/codex/tasks/task_e_68ac865c5bd083278bc5909f41ed46f5