### PR TITLE
Integrate journal service with UI controls

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -2,6 +2,7 @@
 
 #include "app_context.h"
 #include "services/data_service.h"
+#include "services/journal_service.h"
 #include "ui/ui_manager.h"
 #include "core/glfw_context.h"
 
@@ -70,6 +71,7 @@ private:
 
   std::unique_ptr<AppContext> ctx_;
   DataService data_service_;
+  JournalService journal_service_;
   AppStatus status_;
   mutable std::mutex status_mutex_;
   struct WindowDeleter {

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -57,6 +57,7 @@ struct AppContext {
   std::string last_active_pair;
   std::string last_active_interval;
   bool show_analytics_window = false;
+  bool show_journal_window = false;
   std::chrono::milliseconds retry_delay{5000};
   int max_retries = 3;
   bool exponential_backoff = true;

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -414,7 +414,8 @@ void DrawControlPanel(
     const std::vector<std::string> &exchange_pairs, AppStatus &status,
     DataService &data_service,
     const std::function<void(const std::string &)> &cancel_pair,
-    bool &show_analytics_window) {
+    bool &show_analytics_window,
+    bool &show_journal_window) {
   ImGui::Begin("Control Panel");
 
   RenderLoadControls(pairs, selected_pairs, intervals, all_candles, save_pairs,
@@ -426,6 +427,7 @@ void DrawControlPanel(
 
   ImGui::Separator();
   ImGui::Checkbox("Analytics", &show_analytics_window);
+  ImGui::Checkbox("Journal", &show_journal_window);
 
   ImGui::End();
 }

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -27,5 +27,6 @@ void DrawControlPanel(
     AppStatus& status,
     DataService& data_service,
     const std::function<void(const std::string&)>& cancel_pair,
-    bool& show_analytics_window);
+    bool& show_analytics_window,
+    bool& show_journal_window);
 


### PR DESCRIPTION
## Summary
- add JournalService to App and load/save journal on startup and shutdown
- expose Journal window through control panel toggle and render it

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68ac88b6136c8327abbea72f99dbdbf0