### PR TITLE
Add backtest window and integrate with control panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ if(BUILD_TRADING_TERMINAL)
     src/services/data_service.cpp
     src/ui/control_panel.cpp
     src/ui/analytics_window.cpp
+    src/ui/journal_window.cpp
+    src/ui/backtest_window.cpp
     src/ui/ui_manager.cpp
   )
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -31,6 +31,7 @@
 #include "ui/control_panel.h"
 #include "ui/analytics_window.h"
 #include "ui/journal_window.h"
+#include "ui/backtest_window.h"
 
 static void OnFramebufferResize(GLFWwindow * /*w*/, int width, int height) {
   glViewport(0, 0, width, height);
@@ -590,7 +591,8 @@ void App::render_main_windows() {
                    this->ctx_->save_pairs, this->ctx_->exchange_pairs, status_,
                    data_service_, this->ctx_->cancel_pair,
                    this->ctx_->show_analytics_window,
-                   this->ctx_->show_journal_window);
+                   this->ctx_->show_journal_window,
+                   this->ctx_->show_backtest_window);
   ui_manager_.draw_chart_panel(this->ctx_->selected_pairs,
                                this->ctx_->intervals);
   if (this->ctx_->show_analytics_window) {
@@ -599,6 +601,10 @@ void App::render_main_windows() {
   }
   if (this->ctx_->show_journal_window) {
     DrawJournalWindow(journal_service_);
+  }
+  if (this->ctx_->show_backtest_window) {
+    DrawBacktestWindow(this->ctx_->all_candles, this->ctx_->active_pair,
+                       this->ctx_->selected_interval);
   }
 }
 

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -58,6 +58,7 @@ struct AppContext {
   std::string last_active_interval;
   bool show_analytics_window = false;
   bool show_journal_window = false;
+  bool show_backtest_window = false;
   std::chrono::milliseconds retry_delay{5000};
   int max_retries = 3;
   bool exponential_backoff = true;

--- a/src/ui/backtest_window.cpp
+++ b/src/ui/backtest_window.cpp
@@ -1,0 +1,56 @@
+#include "ui/backtest_window.h"
+
+#include "imgui.h"
+#include "implot.h"
+#include "services/signal_bot.h"
+#include "config_manager.h"
+#include "config_path.h"
+
+void DrawBacktestWindow(
+    const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
+    const std::string& active_pair,
+    const std::string& selected_interval) {
+  ImGui::Begin("Backtest");
+
+  static Core::BacktestResult result;
+  static bool ran = false;
+
+  ImGui::Text("Pair: %s", active_pair.c_str());
+  ImGui::SameLine();
+  ImGui::Text("Interval: %s", selected_interval.c_str());
+
+  if (ImGui::Button("Run Backtest") && !active_pair.empty() && !selected_interval.empty()) {
+    auto pair_it = all_candles.find(active_pair);
+    if (pair_it != all_candles.end()) {
+      auto interval_it = pair_it->second.find(selected_interval);
+      if (interval_it != pair_it->second.end()) {
+        auto cfg = Config::ConfigManager::load(resolve_config_path().string());
+        Config::SignalConfig scfg;
+        if (cfg)
+          scfg = cfg->signal;
+        SignalBot bot(scfg);
+        Core::Backtester bt(interval_it->second, bot);
+        result = bt.run();
+        ran = true;
+      }
+    }
+  }
+
+  if (ran) {
+    ImGui::Text("Total PnL: %.2f", result.total_pnl);
+    ImGui::Text("Win Rate: %.2f%%", result.win_rate * 100.0);
+    if (!result.equity_curve.empty()) {
+      if (ImPlot::BeginPlot("Equity Curve")) {
+        std::vector<double> xs(result.equity_curve.size());
+        for (size_t i = 0; i < xs.size(); ++i)
+          xs[i] = static_cast<double>(i);
+        ImPlot::PlotLine("Equity", xs.data(), result.equity_curve.data(),
+                         static_cast<int>(result.equity_curve.size()));
+        ImPlot::EndPlot();
+      }
+    }
+  }
+
+  ImGui::End();
+}
+

--- a/src/ui/backtest_window.h
+++ b/src/ui/backtest_window.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "core/candle.h"
+
+// DrawBacktestWindow renders a window allowing backtesting on the
+// currently selected pair and interval. It displays summary statistics
+// such as PnL, win rate and the equity curve.
+void DrawBacktestWindow(
+    const std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
+    const std::string& active_pair,
+    const std::string& selected_interval);
+

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -415,7 +415,8 @@ void DrawControlPanel(
     DataService &data_service,
     const std::function<void(const std::string &)> &cancel_pair,
     bool &show_analytics_window,
-    bool &show_journal_window) {
+    bool &show_journal_window,
+    bool &show_backtest_window) {
   ImGui::Begin("Control Panel");
 
   RenderLoadControls(pairs, selected_pairs, intervals, all_candles, save_pairs,
@@ -428,6 +429,7 @@ void DrawControlPanel(
   ImGui::Separator();
   ImGui::Checkbox("Analytics", &show_analytics_window);
   ImGui::Checkbox("Journal", &show_journal_window);
+  ImGui::Checkbox("Backtest", &show_backtest_window);
 
   ImGui::End();
 }

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -28,5 +28,6 @@ void DrawControlPanel(
     DataService& data_service,
     const std::function<void(const std::string&)>& cancel_pair,
     bool& show_analytics_window,
-    bool& show_journal_window);
+    bool& show_journal_window,
+    bool& show_backtest_window);
 


### PR DESCRIPTION
## Summary
- Add backtest window that runs Core::Backtester with SignalBot and plots equity curve
- Hook up Backtest window toggle in control panel and render_main_windows
- Wire new UI files into build system

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr" with any of the following names: cprConfig.cmake, cpr-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e156f20832794580eaf156c9516