### PR TITLE
Expose drawing enums in UiManager public interface

### DIFF
--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -46,6 +46,9 @@ public:
   void end_frame(GLFWwindow *window);
   void shutdown();
 
+  enum class DrawTool { None, Line, HLine, Ruler, Long, Short, Fibo };
+  enum class SeriesType { Candlestick, Line, Area };
+
   struct Position {
     int id;
     bool is_long;
@@ -60,8 +63,6 @@ public:
 
 private:
   std::vector<Core::Candle> candles_;
-  enum class DrawTool { None, Line, HLine, Ruler, Long, Short, Fibo };
-  enum class SeriesType { Candlestick, Line, Area };
   struct DrawObject {
     DrawTool type;
     double x1;


### PR DESCRIPTION
## Summary
- Move `DrawTool` and `SeriesType` enums to the public section of `UiManager`
- Leave internal state members `current_tool_` and `current_series_` private

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68ac950182a8832782b1170e881932fe