### PR TITLE
Avoid redeclaring idx in PlotCandlestick tooltip

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -120,7 +120,7 @@ void PlotCandlestick(const char *label_id, const double *xs,
         --it;
       idx = static_cast<int>(it - xs);
     }
-    int idx = BinarySearch(xs, 0, count - 1, rounded_x);
+    idx = BinarySearch(xs, 0, count - 1, rounded_x);
     if (idx != -1) {
       ImGui::BeginTooltip();
       auto tp = std::chrono::system_clock::time_point(


### PR DESCRIPTION
## Summary
- Reuse the existing `idx` variable when computing tooltip data for candlesticks to avoid shadowing

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr" with any of the following names: cprConfig.cmake, cpr-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68acb70b1d7083279d7f4eebfa717670