### PR TITLE
Add signal source to TradingTerminal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ if(BUILD_TRADING_TERMINAL)
     src/ui/analytics_window.cpp
     src/ui/journal_window.cpp
     src/ui/backtest_window.cpp
-    src/ui/ui_manager.cpp
+    src/ui/ui_manager.cpp,
+    src/signal.cpp
   )
 
   target_sources(TradingTerminal PRIVATE


### PR DESCRIPTION
## Summary
- include `src/signal.cpp` in TradingTerminal target so signal functions link

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

*Note:* Building the full TradingTerminal executable requires `cpr`, which is unavailable in this environment.

------
https://chatgpt.com/codex/tasks/task_e_68acc9d876fc832780fe2b44501f8072