### PR TITLE
Remove trailing comma from ui_manager source entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(BUILD_TRADING_TERMINAL)
     src/ui/analytics_window.cpp
     src/ui/journal_window.cpp
     src/ui/backtest_window.cpp
-    src/ui/ui_manager.cpp,
+    src/ui/ui_manager.cpp
     src/signal.cpp
   )
 


### PR DESCRIPTION
## Summary
- fix CMake source list by removing trailing comma from `src/ui/ui_manager.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68acd135369c8327873c923d65f8f9d4