### PR TITLE
Fix candle updates and add integrity checks

### DIFF
--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -21,6 +21,9 @@ public:
     // Appends new candles to an existing CSV file, skipping duplicates.
     bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const;
 
+    // Validates existing candle data for a symbol/interval.
+    bool validate_candles(const std::string& symbol, const std::string& interval) const;
+
     // Loads candles from a CSV file into a vector.
     std::vector<Candle> load_candles(const std::string& symbol, const std::string& interval) const;
 


### PR DESCRIPTION
## Summary
- Append all fetched candles instead of only the latest and refresh chart state
- Add CSV candle validation and reload corrupted data automatically
- Re-validate candle files after save/append operations

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr")*


------
https://chatgpt.com/codex/tasks/task_e_68acd52151a88327bbb7000f38f106c7