### PR TITLE
Add timeout and header support to HTTP client

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -12,8 +12,12 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <thread>
+#include <map>
 
 namespace {
+
+constexpr std::chrono::milliseconds kHttpTimeout{10000};
+const std::map<std::string, std::string> kDefaultHeaders{};
 
 std::string map_gate_interval(const std::string &interval) {
   static const std::unordered_map<std::string, std::string> mapping{{"5s", "10s"}};
@@ -63,7 +67,7 @@ KlinesResult DataFetcher::fetch_klines_from_api(
     bool success = false;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
       rate_limiter_->acquire();
-      HttpResponse r = http_client_->get(url);
+      HttpResponse r = http_client_->get(url, kHttpTimeout, kDefaultHeaders);
       if (r.network_error) {
         Logger::instance().error("Request error: " + r.error_message);
         if (attempt < max_retries - 1) {
@@ -164,7 +168,7 @@ KlinesResult DataFetcher::fetch_klines_alt(
     bool success = false;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
       rate_limiter_->acquire();
-      HttpResponse r = http_client_->get(url);
+      HttpResponse r = http_client_->get(url, kHttpTimeout, kDefaultHeaders);
       if (r.network_error) {
         Logger::instance().error("Alt request error: " + r.error_message);
         if (attempt < max_retries - 1) {
@@ -238,7 +242,7 @@ SymbolsResult DataFetcher::fetch_all_symbols(
   const std::string url = "https://api.binance.com/api/v3/exchangeInfo";
   for (int attempt = 0; attempt < max_retries; ++attempt) {
     rate_limiter_->acquire();
-    HttpResponse r = http_client_->get(url);
+    HttpResponse r = http_client_->get(url, kHttpTimeout, kDefaultHeaders);
     if (r.network_error) {
       Logger::instance().error("Request error: " + r.error_message);
       if (attempt < max_retries - 1) {
@@ -258,7 +262,7 @@ SymbolsResult DataFetcher::fetch_all_symbols(
         const std::string ticker_url =
             "https://api.binance.com/api/v3/ticker/24hr";
         rate_limiter_->acquire();
-        HttpResponse t = http_client_->get(ticker_url);
+        HttpResponse t = http_client_->get(ticker_url, kHttpTimeout, kDefaultHeaders);
         if (t.network_error) {
           Logger::instance().error("Ticker request failed: " +
                                    t.error_message);
@@ -323,7 +327,7 @@ IntervalsResult DataFetcher::fetch_all_intervals(
   const std::string url = "https://api.binance.com/api/v3/exchangeInfo";
   for (int attempt = 0; attempt < max_retries; ++attempt) {
     rate_limiter_->acquire();
-    HttpResponse r = http_client_->get(url);
+    HttpResponse r = http_client_->get(url, kHttpTimeout, kDefaultHeaders);
     if (r.network_error) {
       Logger::instance().error("Request error: " + r.error_message);
       if (attempt < max_retries - 1) {

--- a/src/core/net/cpr_http_client.cpp
+++ b/src/core/net/cpr_http_client.cpp
@@ -4,10 +4,14 @@
 
 namespace Core {
 
-HttpResponse CprHttpClient::get(const std::string &url) {
+HttpResponse CprHttpClient::get(const std::string &url,
+                                std::chrono::milliseconds timeout,
+                                const std::map<std::string, std::string> &headers) {
   HttpResponse resp;
   try {
-    auto r = cpr::Get(cpr::Url{url});
+    cpr::Timeout to{timeout.count()};
+    cpr::Header hdr{headers.begin(), headers.end()};
+    auto r = cpr::Get(cpr::Url{url}, to, hdr);
     resp.status_code = static_cast<int>(r.status_code);
     resp.text = std::move(r.text);
     if (r.error.code != cpr::ErrorCode::OK) {

--- a/src/core/net/cpr_http_client.h
+++ b/src/core/net/cpr_http_client.h
@@ -6,7 +6,9 @@ namespace Core {
 
 class CprHttpClient : public IHttpClient {
 public:
-  HttpResponse get(const std::string &url) override;
+  HttpResponse get(const std::string &url,
+                   std::chrono::milliseconds timeout,
+                   const std::map<std::string, std::string> &headers) override;
 };
 
 } // namespace Core

--- a/src/core/net/ihttp_client.h
+++ b/src/core/net/ihttp_client.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <chrono>
+#include <map>
 
 namespace Core {
 
@@ -14,7 +16,9 @@ struct HttpResponse {
 class IHttpClient {
 public:
   virtual ~IHttpClient() = default;
-  virtual HttpResponse get(const std::string &url) = 0;
+  virtual HttpResponse get(const std::string &url,
+                           std::chrono::milliseconds timeout,
+                           const std::map<std::string, std::string> &headers) = 0;
 };
 
 } // namespace Core

--- a/src/services/data_service.cpp
+++ b/src/services/data_service.cpp
@@ -11,6 +11,13 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 #include <thread>
+#include <chrono>
+#include <map>
+
+namespace {
+constexpr std::chrono::milliseconds kHttpTimeout{10000};
+const std::map<std::string, std::string> kDefaultHeaders{};
+} // namespace
 
 DataService::DataService()
     : http_client_(std::make_shared<Core::CprHttpClient>()),
@@ -94,7 +101,8 @@ Core::KlinesResult DataService::fetch_range(
       auto current_delay = retry_delay;
       for (int attempt = 0; attempt < max_retries; ++attempt) {
         rate_limiter_->acquire();
-        Core::HttpResponse r = http_client_->get(url);
+        Core::HttpResponse r =
+            http_client_->get(url, kHttpTimeout, kDefaultHeaders);
         if (r.network_error) {
           Core::Logger::instance().error("Alt range request error: " +
                                          r.error_message);
@@ -166,7 +174,8 @@ Core::KlinesResult DataService::fetch_range(
       auto current_delay = retry_delay;
       for (int attempt = 0; attempt < max_retries; ++attempt) {
         rate_limiter_->acquire();
-        Core::HttpResponse r = http_client_->get(url);
+        Core::HttpResponse r =
+            http_client_->get(url, kHttpTimeout, kDefaultHeaders);
         if (r.network_error) {
           Core::Logger::instance().error("Range request error: " +
                                          r.error_message);

--- a/tests/test_data_fetcher.cpp
+++ b/tests/test_data_fetcher.cpp
@@ -2,6 +2,8 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <chrono>
+#include <map>
 
 
 class DummyLimiter : public Core::IRateLimiter {
@@ -14,7 +16,9 @@ public:
   std::vector<Core::HttpResponse> responses;
   std::vector<std::string> urls;
   size_t index{0};
-  Core::HttpResponse get(const std::string &url) override {
+  Core::HttpResponse get(const std::string &url,
+                         std::chrono::milliseconds /*timeout*/,
+                         const std::map<std::string, std::string> & /*headers*/) override {
     urls.push_back(url);
     if (index < responses.size())
       return responses[index++];


### PR DESCRIPTION
## Summary
- extend Http client interface to accept timeout and headers
- apply cpr::Timeout and cpr::Header in `cpr_http_client`
- propagate new parameters through DataFetcher, DataService and tests

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68acd97dd96083279a8ec333f40f5e4b