### PR TITLE
Use shared fill_missing helper

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -4,6 +4,7 @@
 #include "config_path.h"
 #include "core/candle.h"
 #include "core/candle_manager.h"
+#include "core/candle_utils.h"
 #include "core/interval_utils.h"
 #include "core/kline_stream.h"
 #include "core/logger.h"
@@ -215,28 +216,7 @@ void App::load_existing_candles() {
           }
         }
         if (fixed) {
-          auto fill_missing = [](std::vector<Core::Candle> &vec,
-                                 long long period_ms) {
-            if (vec.size() < 2 || period_ms <= 0)
-              return;
-            std::vector<Core::Candle> filled;
-            filled.reserve(vec.size());
-            for (std::size_t j = 0; j + 1 < vec.size(); ++j) {
-              const auto &c = vec[j];
-              const auto &n = vec[j + 1];
-              filled.push_back(c);
-              long long exp = c.open_time + period_ms;
-              while (exp < n.open_time) {
-                filled.emplace_back(exp, c.close, c.close, c.close, c.close,
-                                    0.0, exp + period_ms - 1, 0.0, 0, 0.0, 0.0,
-                                    0.0);
-                exp += period_ms;
-              }
-            }
-            filled.push_back(vec.back());
-            vec = std::move(filled);
-          };
-          fill_missing(candles, interval_ms);
+          Core::fill_missing(candles, interval_ms);
         }
       }
     }

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -10,31 +10,10 @@
 #include "core/logger.h"
 #include "interval_utils.h"
 #include "core/data_dir.h"
+#include "candle_utils.h"
 
 namespace Core {
 
-namespace {
-
-void fill_missing(std::vector<Candle> &candles, long long interval_ms) {
-    if (candles.size() < 2 || interval_ms <= 0) return;
-    std::vector<Candle> filled;
-    filled.reserve(candles.size());
-    for (std::size_t i = 0; i + 1 < candles.size(); ++i) {
-        const auto &cur = candles[i];
-        const auto &next = candles[i + 1];
-        filled.push_back(cur);
-        long long expected = cur.open_time + interval_ms;
-        while (expected < next.open_time) {
-            filled.emplace_back(expected, cur.close, cur.close, cur.close, cur.close,
-                               0.0, expected + interval_ms - 1, 0.0, 0, 0.0, 0.0, 0.0);
-            expected += interval_ms;
-        }
-    }
-    filled.push_back(candles.back());
-    candles = std::move(filled);
-}
-
-} // unnamed namespace
 
 CandleManager::CandleManager() : data_dir_(resolve_data_dir()) {}
 
@@ -392,7 +371,7 @@ std::vector<Candle> CandleManager::load_candles_from_json(const std::string& sym
 
     auto interval_ms = parse_interval(interval).count();
     if (interval_ms > 0) {
-        fill_missing(candles, interval_ms);
+        Core::fill_missing(candles, interval_ms);
     } else {
         Logger::instance().warn("Could not determine interval '" + interval + "' for " + symbol);
     }
@@ -475,7 +454,7 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
 
     auto interval_ms = parse_interval(interval).count();
     if (interval_ms > 0) {
-        fill_missing(candles, interval_ms);
+        Core::fill_missing(candles, interval_ms);
     } else {
         Logger::instance().warn("Could not determine interval '" + interval + "' for " + symbol);
     }


### PR DESCRIPTION
## Summary
- Remove local `fill_missing` implementations from `CandleManager` and `App`
- Use `Core::fill_missing` helper for candle data gaps
- Include shared candle utilities header where needed

## Testing
- `cmake -S . -B build` *(fails: Could not find cprConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68acdd2384448327b9a393c440091594