### PR TITLE
Handle invalid JSON in kline stream with error callback

### DIFF
--- a/src/core/kline_stream.cpp
+++ b/src/core/kline_stream.cpp
@@ -68,7 +68,7 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb,
     bool closed = false;
 
     ws_->setUrl(url);
-    ws_->setOnMessage([this, cb, ui_cb](const std::string &msg) {
+    ws_->setOnMessage([this, cb, err_cb, ui_cb](const std::string &msg) {
       try {
         auto j = nlohmann::json::parse(msg);
         if (j.contains("k")) {
@@ -100,6 +100,8 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb,
         }
       } catch (const std::exception &e) {
         Logger::instance().error(std::string("Kline parse error: ") + e.what());
+        if (err_cb)
+          err_cb();
       }
     });
     ws_->setOnError([&]() {


### PR DESCRIPTION
## Summary
- propagate error callback in kline stream message handler and invoke on JSON parse failure
- test that malformed JSON triggers the error callback

## Testing
- `g++ -std=c++20 -pthread tests/test_kline_stream.cpp src/core/kline_stream.cpp src/core/iwebsocket.cpp src/core/candle_manager.cpp src/core/data_dir.cpp src/core/interval_utils.cpp src/candle.cpp src/core/logger.cpp src/config_path.cpp src/core/path_utils.cpp src/core/candle_utils.cpp -I src -I include -I third_party/imgui -lgtest -lgtest_main -o build/test_kline_stream_manual && ./build/test_kline_stream_manual`

------
https://chatgpt.com/codex/tasks/task_e_68acde61b3dc832794348a8197911a8e