### PR TITLE
Fix Timeout narrowing in CprHttpClient

### DIFF
--- a/src/core/net/cpr_http_client.cpp
+++ b/src/core/net/cpr_http_client.cpp
@@ -9,7 +9,7 @@ HttpResponse CprHttpClient::get(const std::string &url,
                                 const std::map<std::string, std::string> &headers) {
   HttpResponse resp;
   try {
-    cpr::Timeout to{timeout.count()};
+    cpr::Timeout to{static_cast<int32_t>(timeout.count())};
     cpr::Header hdr{headers.begin(), headers.end()};
     auto r = cpr::Get(cpr::Url{url}, to, hdr);
     resp.status_code = static_cast<int>(r.status_code);


### PR DESCRIPTION
## Summary
- cast std::chrono duration to int32_t when constructing cpr::Timeout

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6dcd7d1c832799197c9ac0508d69