### PR TITLE
Handle invalid fetch interval

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -48,6 +48,10 @@ KlinesResult DataFetcher::fetch_klines_from_api(
   std::vector<Candle> all_candles;
   all_candles.reserve(limit);
   auto interval_ms = parse_interval(interval).count();
+  if (interval_ms <= 0) {
+    Logger::instance().error("Invalid interval: " + interval);
+    return {FetchError::InvalidInterval, 0, "Invalid interval", {}};
+  }
 
   auto now = std::chrono::system_clock::now();
   long long current_ms =
@@ -135,6 +139,9 @@ KlinesResult DataFetcher::fetch_klines(
   auto res = fetch_klines_from_api(
       "https://api.binance.com/api/v3/klines?symbol=", symbol, interval, limit,
       max_retries, retry_delay);
+  if (res.error == FetchError::InvalidInterval) {
+    return res;
+  }
   if (res.error != FetchError::None) {
     return fetch_klines_alt(symbol, interval, limit, max_retries, retry_delay);
   }

--- a/src/core/data_fetcher.h
+++ b/src/core/data_fetcher.h
@@ -17,7 +17,8 @@ enum class FetchError {
   None = 0,        // No error
   HttpError = 1,   // Non-200 HTTP status
   ParseError = 2,  // Failed to parse response
-  NetworkError = 3 // Network level failure
+  NetworkError = 3, // Network level failure
+  InvalidInterval = 4 // Invalid or empty interval
 };
 
 struct KlinesResult {

--- a/tests/test_data_fetcher.cpp
+++ b/tests/test_data_fetcher.cpp
@@ -87,6 +87,16 @@ TEST(DataFetcherTest, AsyncDelegatesToSync) {
   ASSERT_EQ(res.candles.size(), 1u);
 }
 
+TEST(DataFetcherTest, RejectsInvalidInterval) {
+  auto http = std::make_shared<FakeHttpClient>();
+  auto limiter = std::make_shared<DummyLimiter>();
+  Core::DataFetcher fetcher(http, limiter);
+  auto res = fetcher.fetch_klines("BTCUSDT", "", 1);
+  EXPECT_EQ(res.error, Core::FetchError::InvalidInterval);
+  EXPECT_TRUE(res.candles.empty());
+  EXPECT_EQ(http->urls.size(), 0u);
+}
+
 TEST(DataFetcherTest, AltApiBatchesRequestsOverLimit) {
   auto http = std::make_shared<FakeHttpClient>();
   http->responses.push_back({200, make_gate_response(10000, 1000, 10), "", false});


### PR DESCRIPTION
## Summary
- validate parsed interval before kline fetch to avoid division by zero
- add FetchError::InvalidInterval and propagate to callers
- test invalid interval handling in DataFetcher

## Testing
- `ctest --test-dir build` *(fails: test_kline_stream subprocess aborted: Fatal glibc error: tpp.c:83 (__pthread_tpp_change_priority): assertion failed: new_prio == -1 || (new_prio >= fifo_min_prio && new_prio <= fifo_max_prio))*
- `ctest --test-dir build -E test_kline_stream`

------
https://chatgpt.com/codex/tasks/task_e_68ad73bca1cc8327be82ec7de99988d7