### PR TITLE
Filter invalid stored data files

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -148,8 +148,11 @@ void App::load_pairs(std::vector<std::string> &pair_names) {
       auto lp = entry.rfind(" (");
       auto rp = entry.rfind(')');
       if (lp != std::string::npos && rp != std::string::npos && lp < rp) {
+        auto interval = entry.substr(lp + 2, rp - lp - 2);
+        if (interval == "unknown format")
+          continue;
         pairs_found.insert(entry.substr(0, lp));
-        intervals_found.insert(entry.substr(lp + 2, rp - lp - 2));
+        intervals_found.insert(interval);
       }
     }
     pair_names.assign(pairs_found.begin(), pairs_found.end());

--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -578,17 +578,14 @@ std::vector<std::string> CandleManager::list_stored_data() const {
     if (std::filesystem::exists(data_dir_) && std::filesystem::is_directory(data_dir_)) {
         for (const auto& entry : std::filesystem::directory_iterator(data_dir_)) {
             if (entry.is_regular_file() && entry.path().extension() == ".csv") {
-                std::string filename = entry.path().filename().string();
-                // Assuming filename format is SYMBOL_INTERVAL.csv
-                // Extract SYMBOL and INTERVAL
-                size_t last_underscore = filename.rfind('_');
-                size_t dot_csv = filename.rfind(".csv");
-                if (last_underscore != std::string::npos && dot_csv != std::string::npos && last_underscore < dot_csv) {
-                    std::string symbol = filename.substr(0, last_underscore);
-                    std::string interval = filename.substr(last_underscore + 1, dot_csv - (last_underscore + 1));
-                    stored_files.push_back(symbol + " (" + interval + ")");
-                } else {
-                    stored_files.push_back(filename + " (unknown format)");
+                std::string stem = entry.path().stem().string();
+                size_t last_underscore = stem.rfind('_');
+                if (last_underscore != std::string::npos) {
+                    std::string symbol = stem.substr(0, last_underscore);
+                    std::string interval = stem.substr(last_underscore + 1);
+                    if (!symbol.empty() && !interval.empty()) {
+                        stored_files.push_back(symbol + " (" + interval + ")");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ignore stored CSV files that don't match SYMBOL_INTERVAL format
- skip pairs with unknown interval format when loading pairs

## Testing
- `cmake .. -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: test_kline_stream subprocess aborted, test_ui_manager segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68ad84af1d3c832795778adc2e11335c