### PR TITLE
Restrict interval options to existing candle data

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -66,6 +66,7 @@ private:
   void render_status_window();
   void render_main_windows();
   void handle_active_pair_change();
+  void update_available_intervals();
   void start_fetch_thread();
   void stop_fetch_thread();
 

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -24,6 +24,7 @@ struct AppContext {
   std::string active_pair;
   std::string active_interval;
   std::vector<std::string> intervals;
+  std::vector<std::string> available_intervals;
   std::vector<std::string> exchange_pairs;
   std::string selected_interval;
   std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -254,14 +254,18 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
     if (intervals[i] == current_interval_)
       interval_index = static_cast<int>(i);
   }
-  if (ImGui::Combo("Interval", &interval_index, interval_items.data(),
-                   static_cast<int>(interval_items.size()))) {
-    if (interval_index >= 0 &&
-        interval_index < static_cast<int>(intervals.size())) {
-      current_interval_ = intervals[interval_index];
-      if (on_interval_changed_)
-        on_interval_changed_(current_interval_);
+  if (!interval_items.empty()) {
+    if (ImGui::Combo("Interval", &interval_index, interval_items.data(),
+                     static_cast<int>(interval_items.size()))) {
+      if (interval_index >= 0 &&
+          interval_index < static_cast<int>(intervals.size())) {
+        current_interval_ = intervals[interval_index];
+        if (on_interval_changed_)
+          on_interval_changed_(current_interval_);
+      }
     }
+  } else {
+    ImGui::Text("No intervals");
   }
   ImGui::SameLine();
   if (ImGui::Button("Fit")) {


### PR DESCRIPTION
## Summary
- Remove hardcoded 15s and 5s defaults
- Build interval list only from files parsed as SYMBOL_INTERVAL.csv
- When changing pair, show only intervals that have existing candle files

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr")*


------
https://chatgpt.com/codex/tasks/task_e_68ad869e4cac83279198938954d7cd71