### PR TITLE
Rename chart series label to chart type and add tooltip

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -274,7 +274,7 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
   int series_index = static_cast<int>(current_series_);
   const char *series_items[] = {"CandlestickSeries", "LineSeries",
                                 "AreaSeries"};
-  if (ImGui::Combo("Series", &series_index, series_items,
+  if (ImGui::Combo("Chart Type", &series_index, series_items,
                    static_cast<int>(IM_ARRAYSIZE(series_items)))) {
     current_series_ = static_cast<SeriesType>(series_index);
 #ifdef HAVE_WEBVIEW
@@ -285,6 +285,8 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
     }
 #endif
   }
+  ImGui::SetItemTooltip(
+      "Selects how the chart is displayed: candlesticks, line, or area.");
   auto set_tool = [&](DrawTool t) {
     current_tool_ = t;
     drawing_first_point_ = false;


### PR DESCRIPTION
## Summary
- Rename `Series` combo label to clearer `Chart Type`
- Add tooltip explaining the chart display options

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ad8878b1a483279c019cdf43c6597d