### PR TITLE
Enable clipboard copy on log double-click

### DIFF
--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -397,7 +397,11 @@ static void RenderStatusPane(AppStatus &status) {
       if (entry.level != Core::LogLevel::Info)
         ImGui::PushStyleColor(ImGuiCol_Text, col);
       std::string line = std::string(buf) + " [" + lvl + "] " + entry.message;
-      ImGui::Selectable(line.c_str(), false, ImGuiSelectableFlags_Disabled);
+      ImGui::Selectable(line.c_str(), false);
+      if (ImGui::IsItemHovered() &&
+          ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+        ImGui::SetClipboardText(line.c_str());
+      }
       if (entry.level != Core::LogLevel::Info)
         ImGui::PopStyleColor();
     }


### PR DESCRIPTION
## Summary
- allow copying status log entries with a double-click
- remove disabled flag from log items so they can be interacted with

## Testing
- `cmake --build build --target test_interval_utils`
- `cd build && ctest -R test_interval_utils`


------
https://chatgpt.com/codex/tasks/task_e_68ad897257008327a476f5ba55220d3d