### PR TITLE
Remove automatic gap filling when loading candles

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -444,13 +444,6 @@ std::vector<Candle> CandleManager::load_candles(const std::string& symbol, const
 
     file.close();
 
-    auto interval_ms = parse_interval(interval).count();
-    if (interval_ms > 0) {
-        Core::fill_missing(candles, interval_ms);
-    } else {
-        Logger::instance().warn("Could not determine interval '" + interval + "' for " + symbol);
-    }
-
     return candles;
 }
 


### PR DESCRIPTION
## Summary
- stop filling missing intervals in `CandleManager::load_candles`
- `load_candles` now returns parsed candles without further adjustment

## Testing
- `ctest --test-dir build -R test_candle_manager`


------
https://chatgpt.com/codex/tasks/task_e_68ada630fddc8327a49a452f8fbe9489