### PR TITLE
Fix webview bindings

### DIFF
--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -329,30 +329,9 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
       webview_ = webview_create(0, nullptr);
       std::string url = std::string("file://") + html_path.generic_string();
       webview_navigate(static_cast<webview_t>(webview_), url.c_str());
-    webview_bind(
-        static_cast<webview_t>(webview_), "setInterval",
-        [](const char *seq, const char *req, void *arg) {
-          auto self = static_cast<UiManager *>(arg);
-          if (self->on_interval_changed_) {
-            try {
-              auto j = nlohmann::json::parse(req);
-              if (j.is_array() && !j.empty())
-                self->on_interval_changed_(j[0].get<std::string>());
-            } catch (...) {
-            }
-          }
-          webview_return(static_cast<webview_t>(self->webview_), seq, 0,
-                         "null");
-        },
-        this);
-    webview_bind(
-        static_cast<webview_t>(webview_), "setPair",
-        [](const char *seq, const char *req, void *arg) {
-          auto self = static_cast<UiManager *>(arg);
-          if (self->on_pair_changed_) {
       webview_bind(
           static_cast<webview_t>(webview_), "setInterval",
-          [](webview_t w, const char *seq, const char *req, void *arg) {
+          [](const char *seq, const char *req, void *arg) {
             auto self = static_cast<UiManager *>(arg);
             if (self->on_interval_changed_) {
               try {
@@ -362,12 +341,13 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
               } catch (...) {
               }
             }
-            webview_return(w, seq, 0, nullptr);
+            webview_return(static_cast<webview_t>(self->webview_), seq, 0,
+                           "null");
           },
           this);
       webview_bind(
           static_cast<webview_t>(webview_), "setPair",
-          [](webview_t w, const char *seq, const char *req, void *arg) {
+          [](const char *seq, const char *req, void *arg) {
             auto self = static_cast<UiManager *>(arg);
             if (self->on_pair_changed_) {
               try {
@@ -377,12 +357,13 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
               } catch (...) {
               }
             }
-            webview_return(w, seq, 0, nullptr);
+            webview_return(static_cast<webview_t>(self->webview_), seq, 0,
+                           "null");
           },
           this);
       webview_bind(
           static_cast<webview_t>(webview_), "status",
-          [](webview_t w, const char *seq, const char *req, void *arg) {
+          [](const char *seq, const char *req, void *arg) {
             auto self = static_cast<UiManager *>(arg);
             if (self->status_callback_) {
               try {
@@ -392,35 +373,28 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
               } catch (...) {
               }
             }
-            webview_return(w, seq, 0, nullptr);
+            webview_return(static_cast<webview_t>(self->webview_), seq, 0,
+                           "null");
           },
           this);
       webview_bind(
           static_cast<webview_t>(webview_), "setTool",
-          [](webview_t w, const char *seq, const char *req, void *arg) {
+          [](const char *seq, const char *req, void *arg) {
             auto self = static_cast<UiManager *>(arg);
             try {
               auto j = nlohmann::json::parse(req);
               if (j.is_array() && !j.empty())
-                self->current_tool_ = ToolFromString(j[0].get<std::string>());
+                self->current_tool_ =
+                    ToolFromString(j[0].get<std::string>());
             } catch (...) {
             }
-          }
-          webview_return(static_cast<webview_t>(self->webview_), seq, 0,
-                         "null");
-        },
-        this);
-    webview_bind(
-        static_cast<webview_t>(webview_), "status",
-        [](const char *seq, const char *req, void *arg) {
-          auto self = static_cast<UiManager *>(arg);
-          if (self->status_callback_) {
-            webview_return(w, seq, 0, nullptr);
+            webview_return(static_cast<webview_t>(self->webview_), seq, 0,
+                           "null");
           },
           this);
       webview_bind(
           static_cast<webview_t>(webview_), "setSeries",
-          [](webview_t w, const char *seq, const char *req, void *arg) {
+          [](const char *seq, const char *req, void *arg) {
             auto self = static_cast<UiManager *>(arg);
             try {
               auto j = nlohmann::json::parse(req);
@@ -429,42 +403,8 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
                     SeriesTypeFromString(j[0].get<std::string>());
             } catch (...) {
             }
-          }
-          webview_return(static_cast<webview_t>(self->webview_), seq, 0,
-                         "null");
-        },
-        this);
-    webview_bind(
-        static_cast<webview_t>(webview_), "setTool",
-        [](const char *seq, const char *req, void *arg) {
-          auto self = static_cast<UiManager *>(arg);
-          try {
-            auto j = nlohmann::json::parse(req);
-            if (j.is_array() && !j.empty())
-              self->current_tool_ =
-                  ToolFromString(j[0].get<std::string>());
-          } catch (...) {
-          }
-          webview_return(static_cast<webview_t>(self->webview_), seq, 0,
-                         "null");
-        },
-        this);
-    webview_bind(
-        static_cast<webview_t>(webview_), "setSeries",
-        [](const char *seq, const char *req, void *arg) {
-          auto self = static_cast<UiManager *>(arg);
-          try {
-            auto j = nlohmann::json::parse(req);
-            if (j.is_array() && !j.empty())
-              self->current_series_ =
-                  SeriesTypeFromString(j[0].get<std::string>());
-          } catch (...) {
-          }
-          webview_return(static_cast<webview_t>(self->webview_), seq, 0,
-                         "null");
-        },
-        this);
-            webview_return(w, seq, 0, nullptr);
+            webview_return(static_cast<webview_t>(self->webview_), seq, 0,
+                           "null");
           },
           this);
       webview_thread_ = std::jthread([this](std::stop_token) {


### PR DESCRIPTION
## Summary
- replace duplicated/malformed webview bindings with clean handlers for interval, pair, status, tool, and series updates

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr" with any of the following names: cprConfig.cmake, cpr-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68adab2493fc8327a454e4feedd6944a