### PR TITLE
Fill gaps before saving candles

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -185,6 +185,11 @@ bool CandleManager::append_candles(const std::string& symbol, const std::string&
         result.push_back(c);
     }
 
+    auto interval_ms = parse_interval(interval).count();
+    if (interval_ms > 0) {
+        Core::fill_missing(result, interval_ms);
+    }
+
     // Save the merged candle set back to disk.
     return save_candles(symbol, interval, result);
 }


### PR DESCRIPTION
## Summary
- ensure `CandleManager::append_candles` fills missing candle intervals before persisting

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: test_kline_stream, test_ui_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68adb0751c408327a036f42c96c528d3