### PR TITLE
Guard AppStatus access with mutex and add helpers

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "app_context.h"
+#include "core/glfw_context.h"
 #include "services/data_service.h"
 #include "services/journal_service.h"
 #include "ui/ui_manager.h"
-#include "core/glfw_context.h"
 
 #include <chrono>
 #include <deque>
@@ -45,6 +45,8 @@ public:
                   std::chrono::system_clock::time_point time =
                       std::chrono::system_clock::now());
   void clear_failed_fetches();
+  void set_error_message(const std::string &msg);
+  AppStatus get_status_snapshot() const;
 
 private:
   bool init_window();

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <cstdint>
 #include <ctime>
+#include <mutex>
 #include <numeric>
 #include <string>
 
@@ -376,7 +377,8 @@ static void RenderPairSelector(
 }
 
 // Render application status information and recent log messages.
-static void RenderStatusPane(AppStatus &status) {
+static void RenderStatusPane(AppStatus &status, std::mutex &status_mutex) {
+  std::lock_guard<std::mutex> lock(status_mutex);
   ImGui::Separator();
   ImGui::Text("Status");
   ImGui::Text("Candles: %.0f%%", status.candle_progress * 100.0f);
@@ -416,7 +418,7 @@ void DrawControlPanel(
         &all_candles,
     const std::function<void()> &save_pairs,
     const std::vector<std::string> &exchange_pairs, AppStatus &status,
-    DataService &data_service,
+    std::mutex &status_mutex, DataService &data_service,
     const std::function<void(const std::string &)> &cancel_pair,
     bool &show_analytics_window, bool &show_journal_window,
     bool &show_backtest_window) {
@@ -430,7 +432,7 @@ void DrawControlPanel(
   RenderPairSelector(pairs, selected_pairs, active_pair, intervals,
                      selected_interval, all_candles, save_pairs, data_service,
                      status, cancel_pair);
-  RenderStatusPane(status);
+  RenderStatusPane(status, status_mutex);
 
   ImGui::Separator();
   ImGui::Checkbox("Analytics", &show_analytics_window);

--- a/src/ui/control_panel.h
+++ b/src/ui/control_panel.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <vector>
-#include <string>
-#include <map>
 #include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
 
 #include "core/candle.h"
 #include "services/data_service.h"
@@ -11,23 +12,19 @@
 struct AppStatus;
 
 struct PairItem {
-    std::string name;
-    bool visible;
+  std::string name;
+  bool visible;
 };
 
 void DrawControlPanel(
-    std::vector<PairItem>& pairs,
-    std::vector<std::string>& selected_pairs,
-    std::string& active_pair,
-    const std::vector<std::string>& intervals,
-    std::string& selected_interval,
-    std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>& all_candles,
-    const std::function<void()>& save_pairs,
-    const std::vector<std::string>& exchange_pairs,
-    AppStatus& status,
-    DataService& data_service,
-    const std::function<void(const std::string&)>& cancel_pair,
-    bool& show_analytics_window,
-    bool& show_journal_window,
-    bool& show_backtest_window);
-
+    std::vector<PairItem> &pairs, std::vector<std::string> &selected_pairs,
+    std::string &active_pair, const std::vector<std::string> &intervals,
+    std::string &selected_interval,
+    std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>
+        &all_candles,
+    const std::function<void()> &save_pairs,
+    const std::vector<std::string> &exchange_pairs, AppStatus &status,
+    std::mutex &status_mutex, DataService &data_service,
+    const std::function<void(const std::string &)> &cancel_pair,
+    bool &show_analytics_window, bool &show_journal_window,
+    bool &show_backtest_window);


### PR DESCRIPTION
## Summary
- Add mutex-guarded `set_error_message` and `get_status_snapshot` helpers on App
- Lock all `status_` reads and writes, including candle progress and initialization
- Pass status mutex to UI control panel and guard RenderStatusPane access

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glfw3")*
- `apt-get install -y libglfw3-dev` *(fails: Unable to locate package libglfw3-dev)*


------
https://chatgpt.com/codex/tasks/task_e_68adc18dbf30832785c8f7d7e45c06bb