### PR TITLE
Ensure fetch thread stops before cleanup

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -482,6 +482,8 @@ void App::start_fetch_thread() {
 void App::stop_fetch_thread() {
   fetch_thread_.request_stop();
   this->ctx_->fetch_cv.notify_all();
+  if (fetch_thread_.joinable())
+    fetch_thread_.join();
 }
 
 void App::process_events() {


### PR DESCRIPTION
## Summary
- join the fetch thread during shutdown so cleanup only runs after thread completion

## Testing
- `cmake .. && cmake --build . && ctest` *(fails: test_ui_manager segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68adc3ff844c8327bebe2b2a2349872d