### PR TITLE
Use thread-safe gmtime variants

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -470,7 +470,12 @@ nlohmann::json CandleManager::load_candles_json(const std::string& symbol,
         long long ms = c.open_time;
         std::time_t sec = ms / 1000;
         int millis = static_cast<int>(ms % 1000);
-        std::tm tm = *std::gmtime(&sec);
+        std::tm tm;
+#if defined(_WIN32)
+        gmtime_s(&tm, &sec);
+#else
+        gmtime_r(&sec, &tm);
+#endif
         std::ostringstream oss;
         oss << std::put_time(&tm, "%FT%T") << '.'
             << std::setw(3) << std::setfill('0') << millis << 'Z';

--- a/src/ui/control_panel.cpp
+++ b/src/ui/control_panel.cpp
@@ -39,9 +39,14 @@ std::string format_date(long long ms) {
   if (ms == 0)
     return "-";
   std::time_t t = ms / 1000;
-  std::tm *tm = std::gmtime(&t);
+  std::tm tm;
+#if defined(_WIN32)
+  gmtime_s(&tm, &t);
+#else
+  gmtime_r(&t, &tm);
+#endif
   char buf[6];
-  if (std::strftime(buf, sizeof(buf), "%d.%m", tm))
+  if (std::strftime(buf, sizeof(buf), "%d.%m", &tm))
     return std::string(buf);
   return "-";
 }

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -117,7 +118,12 @@ void PlotCandlestick(const char *label_id, const double *xs,
       auto tp = std::chrono::system_clock::time_point(
           std::chrono::seconds(static_cast<long long>(xs[idx])));
       std::time_t tt = std::chrono::system_clock::to_time_t(tp);
-      std::tm tm = *std::gmtime(&tt);
+      std::tm tm;
+#if defined(_WIN32)
+      gmtime_s(&tm, &tt);
+#else
+      gmtime_r(&tt, &tm);
+#endif
       std::ostringstream oss;
       oss << std::put_time(&tm, "%Y-%m-%d");
       ImGui::Text("Day:   %s", oss.str().c_str());
@@ -519,7 +525,12 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
           auto tp = std::chrono::system_clock::time_point(
               std::chrono::seconds(static_cast<long long>(mouse.x)));
           std::time_t tt = std::chrono::system_clock::to_time_t(tp);
-          std::tm tm = *std::gmtime(&tt);
+          std::tm tm;
+#if defined(_WIN32)
+          gmtime_s(&tm, &tt);
+#else
+          gmtime_r(&tt, &tm);
+#endif
           char time_buf[32];
           std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M", &tm);
           ImPlot::Annotation(mouse.x, lims.Y.Min, ImVec4(1, 1, 1, 1),


### PR DESCRIPTION
## Summary
- Replace `std::gmtime` with `gmtime_r`/`gmtime_s` in date formatting and time conversion helpers
- Apply the same thread-safe conversion in candle export and UI components
- Include `<ctime>` for UI manager

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: test_ui_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68adc872f0ec832782dabadec1afea29