### PR TITLE
Optimize status log rendering

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -24,12 +24,8 @@ struct GLFWwindow;
 struct AppStatus {
   float candle_progress = 0.0f;
   std::string error_message;
-  struct LogEntry {
-    std::chrono::system_clock::time_point time;
-    Core::LogLevel level;
-    std::string message;
-  };
-  std::deque<LogEntry> log;
+  std::deque<std::string> log;
+  static constexpr size_t kMaxLogEntries = 200;
 };
 
 // The App class owns the services and drives the main event loop.


### PR DESCRIPTION
## Summary
- keep preformatted log lines in a bounded deque
- render log via ImGuiListClipper and allow clearing/copying

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: test_ui_manager SEGFAULT)*

------
https://chatgpt.com/codex/tasks/task_e_68adca8f9db08327b351211dd6f1d298