### PR TITLE
Add logger include to ConfigManager

### DIFF
--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -6,6 +6,7 @@
 
 #include "config_path.h"
 #include "config_schema.h"
+#include "core/logger.h"
 #include "core/path_utils.h"
 
 namespace Config {


### PR DESCRIPTION
## Summary
- include `core/logger.h` in `ConfigManager`

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: test_kline_stream subprocess aborted, test_ui_manager segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68add5afdd288327b35c34d8386d291c