### PR TITLE
Check data_dir config file open before writing

### DIFF
--- a/src/core/data_dir.cpp
+++ b/src/core/data_dir.cpp
@@ -45,9 +45,12 @@ std::filesystem::path resolve_data_dir() {
         }
         j["data_dir"] = dir.string();
         std::ofstream out(cfg_path);
-        if (out.is_open()) {
-            out << j.dump(4);
+        if (!out.is_open()) {
+            Logger::instance().error("Failed to open " + cfg_path.string() + " for writing");
+            std::filesystem::create_directories(dir);
+            return dir;
         }
+        out << j.dump(4);
     }
 
     std::filesystem::create_directories(dir);


### PR DESCRIPTION
## Summary
- Validate the config file stream when saving default data directory
- Log an error and skip writing if the config file can't be opened

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GTest" with any of the following names: GTestConfig.cmake, gtest-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68add97ad6208327839398b383e9d8ad