### PR TITLE
Use real newline for candle CSV output

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -118,7 +118,8 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
         }
 
         // Write header
-        file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore\n";
+        file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore
+";
         file.setf(std::ios::fixed);
         file << std::setprecision(8);
 
@@ -135,7 +136,8 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
                  << candle.number_of_trades << ","
                  << candle.taker_buy_base_asset_volume << ","
                  << candle.taker_buy_quote_asset_volume << ","
-                 << candle.ignore << "\n";
+                 << candle.ignore << "
+";
         }
 
         file.close();


### PR DESCRIPTION
## Summary
- write CSV header using an actual newline instead of escaped sequence
- use real newline when emitting individual candle records

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ade37fe4ac8327ac5e3897410f0da2