### PR TITLE
Ensure CandleManager path access is thread-safe

### DIFF
--- a/src/core/candle_manager.cpp
+++ b/src/core/candle_manager.cpp
@@ -34,21 +34,24 @@ std::filesystem::path CandleManager::get_data_dir() const {
 }
 
 std::filesystem::path CandleManager::get_candle_path(const std::string& symbol, const std::string& interval) const {
-    std::filesystem::create_directories(data_dir_); // Ensure directory exists
+    auto dir = get_data_dir();
+    std::filesystem::create_directories(dir); // Ensure directory exists
     std::string filename = symbol + "_" + interval + ".csv";
-    return data_dir_ / filename;
+    return dir / filename;
 }
 
 std::filesystem::path CandleManager::get_candle_json_path(const std::string& symbol, const std::string& interval) const {
-    std::filesystem::create_directories(data_dir_);
+    auto dir = get_data_dir();
+    std::filesystem::create_directories(dir);
     std::string filename = symbol + "_" + interval + ".json";
-    return data_dir_ / filename;
+    return dir / filename;
 }
 
 std::filesystem::path CandleManager::get_index_path(const std::string& symbol, const std::string& interval) const {
-    std::filesystem::create_directories(data_dir_);
+    auto dir = get_data_dir();
+    std::filesystem::create_directories(dir);
     std::string filename = symbol + "_" + interval + ".idx";
-    return data_dir_ / filename;
+    return dir / filename;
 }
 
 long long CandleManager::read_last_open_time(const std::string& symbol, const std::string& interval) const {
@@ -118,8 +121,7 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
         }
 
         // Write header
-        file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore
-";
+        file << "open_time,open,high,low,close,volume,close_time,quote_asset_volume,number_of_trades,taker_buy_base_asset_volume,taker_buy_quote_asset_volume,ignore";
         file.setf(std::ios::fixed);
         file << std::setprecision(8);
 
@@ -136,8 +138,7 @@ bool CandleManager::save_candles(const std::string& symbol, const std::string& i
                  << candle.number_of_trades << ","
                  << candle.taker_buy_base_asset_volume << ","
                  << candle.taker_buy_quote_asset_volume << ","
-                 << candle.ignore << "
-";
+                 << candle.ignore << "\n";
         }
 
         file.close();


### PR DESCRIPTION
## Summary
- Guard candle path helpers with `get_data_dir()` to avoid data directory races
- Fix newline handling in `save_candles`

## Testing
- `cmake -B build -S . -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure --timeout 60` *(fails: test_candle_manager timeout; test_ui_manager segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68aded360c388327ad3762c98e6343eb