### PR TITLE
Remove redundant kline gap filling

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -150,7 +150,8 @@ KlinesResult DataFetcher::fetch_klines(
   if (res.error != FetchError::None) {
     return fetch_klines_alt(symbol, interval, limit, max_retries, retry_delay);
   }
-  fill_missing(res.candles, parse_interval(interval).count());
+  // fetch_klines_from_api already performs fill_missing on the candle data,
+  // so avoid doing it again here.
   return res;
 }
 


### PR DESCRIPTION
## Summary
- Avoid double calling `fill_missing` in `DataFetcher::fetch_klines`

## Testing
- `cmake --build build --target test_data_fetcher -j 4`
- `ctest --test-dir build -R test_data_fetcher --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68adfecaf8508327b32c8ad3dac949ed