### PR TITLE
Use thread-safe localtime in journal window

### DIFF
--- a/src/ui/journal_window.cpp
+++ b/src/ui/journal_window.cpp
@@ -53,7 +53,12 @@ void DrawJournalWindow(JournalService &service, bool save_csv) {
 
   auto format_timestamp = [](std::int64_t ms) {
     std::time_t t = ms / 1000;
-    std::tm tm = *std::localtime(&t);
+    std::tm tm;
+#if defined(_WIN32)
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
     std::ostringstream oss;
     oss << std::put_time(&tm, "%Y-%m-%d %H:%M");
     return oss.str();


### PR DESCRIPTION
## Summary
- Use platform-specific thread-safe localtime functions in journal window helper

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "cpr")*
- `g++ -std=c++20 -Isrc -Iinclude -Ithird_party/imgui -c src/ui/journal_window.cpp -o /tmp/journal_window.o`


------
https://chatgpt.com/codex/tasks/task_e_68ae004c6454832789e3e0226912c838