### PR TITLE
Use thread-safe localtime in signals window

### DIFF
--- a/src/ui/signals_window.cpp
+++ b/src/ui/signals_window.cpp
@@ -196,8 +196,14 @@ void DrawSignalsWindow(
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
       std::time_t tt = static_cast<std::time_t>(signal_entries[i].time);
-      std::tm *tm = std::localtime(&tt);
-      if (tm && std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", tm)) {
+      std::tm tm{};
+      bool time_ok = false;
+#if defined(_WIN32)
+      time_ok = localtime_s(&tm, &tt) == 0;
+#else
+      time_ok = localtime_r(&tt, &tm) != nullptr;
+#endif
+      if (time_ok && std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tm)) {
         ImGui::TextUnformatted(buf);
       } else {
         ImGui::Text("%lld", static_cast<long long>(signal_entries[i].time));


### PR DESCRIPTION
## Summary
- replace `std::localtime` with platform-specific `localtime_s` or `localtime_r` in the signals table renderer

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=ON`
- `cmake --build build`
- `ctest --output-on-failure` *(fails: test suite hangs on first test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae010fc36083278a9c44855222824d