### PR TITLE
Refactor interval initialization in update_available_intervals

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -257,10 +257,8 @@ void App::update_available_intervals() {
       this->ctx_->active_interval = this->ctx_->available_intervals.front();
       this->ctx_->selected_interval = this->ctx_->active_interval;
     }
-    ui_manager_.set_initial_interval(this->ctx_->active_interval);
-  } else {
-    ui_manager_.set_initial_interval(this->ctx_->active_interval);
   }
+  ui_manager_.set_initial_interval(this->ctx_->active_interval);
 }
 
 void App::load_existing_candles() {


### PR DESCRIPTION
## Summary
- avoid redundant calls to set_initial_interval by moving it outside the conditional in update_available_intervals

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build` *(fails: undefined reference to `DataService::DataService()`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12d5abfc8327bbe3f7bd25bb71cc