### PR TITLE
Remove explicit join from fetch thread shutdown

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -495,8 +495,7 @@ void App::start_fetch_thread() {
 void App::stop_fetch_thread() {
   fetch_thread_.request_stop();
   this->ctx_->fetch_cv.notify_all();
-  if (fetch_thread_.joinable())
-    fetch_thread_.join();
+  fetch_thread_ = std::jthread();
 }
 
 void App::process_events() {


### PR DESCRIPTION
## Summary
- Stop fetch thread without manual join by resetting the `std::jthread`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b51b2fc8327992480f7e51ce568