### PR TITLE
Handle ImGui backend initialization failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,10 +222,11 @@ add_test(NAME test_kline_stream COMMAND test_kline_stream)
   target_link_libraries(test_signal PRIVATE GTest::gtest_main)
   add_test(NAME test_signal COMMAND test_signal)
 
-  add_executable(test_ui_manager
+add_executable(test_ui_manager
     tests/test_ui_manager.cpp
     src/ui/ui_manager.cpp
     src/core/path_utils.cpp
+    src/core/logger.cpp
   )
   target_include_directories(test_ui_manager PRIVATE tests/stubs src include third_party/imgui third_party/implot)
   target_link_libraries(test_ui_manager PRIVATE GTest::gtest_main imgui::imgui implot::implot)

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "core/path_utils.h"
+#include "core/logger.h"
 #ifndef _WIN32
 #include <sys/resource.h>
 #endif
@@ -201,8 +202,16 @@ bool UiManager::setup(GLFWwindow *window) {
     ImGui::LoadIniSettingsFromDisk(io.IniFilename);
   }
   ImGui::StyleColorsDark();
-  ImGui_ImplGlfw_InitForOpenGL(window, true);
-  ImGui_ImplOpenGL3_Init("#version 130");
+  if (!ImGui_ImplGlfw_InitForOpenGL(window, true)) {
+    Core::Logger::instance().error(
+        "Failed to initialize ImGui GLFW backend");
+    return false;
+  }
+  if (!ImGui_ImplOpenGL3_Init("#version 130")) {
+    Core::Logger::instance().error(
+        "Failed to initialize ImGui OpenGL3 backend");
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- log and abort UiManager setup when ImGui GLFW or OpenGL3 backends fail to initialize
- include logger in test_ui_manager build to satisfy new dependency

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF` *(fails: Could not find a package configuration file provided by "GTest")*
- `cmake --build build -j$(nproc)` *(fails: undefined reference to `DataService::DataService()`)*
- `cmake --build build --target test_ui_manager -j$(nproc)`
- `cd build && ctest -R test_ui_manager --output-on-failure` *(fails: SegFault)*

------
https://chatgpt.com/codex/tasks/task_e_68ae26f3702c832781ba802446add726