### PR TITLE
Cache pair and interval lists in UiManager

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -725,8 +725,9 @@ void App::render_main_windows() {
   }
   {
     std::shared_lock<std::shared_mutex> lock(this->ctx_->candles_mutex);
-    ui_manager_.draw_chart_panel(this->ctx_->selected_pairs,
-                                 this->ctx_->available_intervals);
+    ui_manager_.set_pairs(this->ctx_->selected_pairs);
+    ui_manager_.set_intervals(this->ctx_->available_intervals);
+    ui_manager_.draw_chart_panel();
     if (this->ctx_->show_analytics_window) {
       DrawAnalyticsWindow(this->ctx_->all_candles, this->ctx_->active_pair,
                           this->ctx_->selected_interval);

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -232,8 +232,29 @@ void UiManager::begin_frame() {
   ImGui::NewFrame();
 }
 
-void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
-                                 const std::vector<std::string> &intervals) {
+void UiManager::set_pairs(const std::vector<std::string> &pairs) {
+  if (pairs != pair_strings_) {
+    pair_strings_ = pairs;
+    pair_items_.clear();
+    pair_items_.reserve(pair_strings_.size());
+    for (auto &p : pair_strings_) {
+      pair_items_.push_back(p.c_str());
+    }
+  }
+}
+
+void UiManager::set_intervals(const std::vector<std::string> &intervals) {
+  if (intervals != interval_strings_) {
+    interval_strings_ = intervals;
+    interval_items_.clear();
+    interval_items_.reserve(interval_strings_.size());
+    for (auto &i : interval_strings_) {
+      interval_items_.push_back(i.c_str());
+    }
+  }
+}
+
+void UiManager::draw_chart_panel() {
   // Display the currently selected interval in the panel title so users can
   // easily confirm the timeframe of the data being shown. If the interval is
   // empty, fall back to the plain "Chart" title.
@@ -247,36 +268,30 @@ void UiManager::draw_chart_panel(const std::vector<std::string> &pairs,
   ImGui::Begin(title.c_str());
 
   int pair_index = 0;
-  std::vector<const char *> pair_items;
-  pair_items.reserve(pairs.size());
-  for (std::size_t i = 0; i < pairs.size(); ++i) {
-    pair_items.push_back(pairs[i].c_str());
-    if (pairs[i] == current_pair_)
+  for (std::size_t i = 0; i < pair_strings_.size(); ++i) {
+    if (pair_strings_[i] == current_pair_)
       pair_index = static_cast<int>(i);
   }
-  if (ImGui::Combo("Pair", &pair_index, pair_items.data(),
-                   static_cast<int>(pair_items.size()))) {
-    if (pair_index >= 0 && pair_index < static_cast<int>(pairs.size())) {
-      current_pair_ = pairs[pair_index];
+  if (ImGui::Combo("Pair", &pair_index, pair_items_.data(),
+                   static_cast<int>(pair_items_.size()))) {
+    if (pair_index >= 0 && pair_index < static_cast<int>(pair_strings_.size())) {
+      current_pair_ = pair_strings_[pair_index];
       if (on_pair_changed_)
         on_pair_changed_(current_pair_);
     }
   }
 
   int interval_index = 0;
-  std::vector<const char *> interval_items;
-  interval_items.reserve(intervals.size());
-  for (std::size_t i = 0; i < intervals.size(); ++i) {
-    interval_items.push_back(intervals[i].c_str());
-    if (intervals[i] == current_interval_)
+  for (std::size_t i = 0; i < interval_strings_.size(); ++i) {
+    if (interval_strings_[i] == current_interval_)
       interval_index = static_cast<int>(i);
   }
-  if (!interval_items.empty()) {
-    if (ImGui::Combo("Interval", &interval_index, interval_items.data(),
-                     static_cast<int>(interval_items.size()))) {
+  if (!interval_items_.empty()) {
+    if (ImGui::Combo("Interval", &interval_index, interval_items_.data(),
+                     static_cast<int>(interval_items_.size()))) {
       if (interval_index >= 0 &&
-          interval_index < static_cast<int>(intervals.size())) {
-        current_interval_ = intervals[interval_index];
+          interval_index < static_cast<int>(interval_strings_.size())) {
+        current_interval_ = interval_strings_[interval_index];
         if (on_interval_changed_)
           on_interval_changed_(current_interval_);
         ImGuiIO &io = ImGui::GetIO();

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -20,9 +20,14 @@ public:
   ~UiManager();
   bool setup(GLFWwindow *window);
   void begin_frame();
+  // Update available trading pairs. Only rebuilds internal arrays if the
+  // provided list differs from the currently cached one.
+  void set_pairs(const std::vector<std::string> &pairs);
+  // Update available intervals. Only rebuilds internal arrays if the provided
+  // list differs from the currently cached one.
+  void set_intervals(const std::vector<std::string> &intervals);
   // Draw docked panels each frame.
-  void draw_chart_panel(const std::vector<std::string> &pairs,
-                        const std::vector<std::string> &intervals);
+  void draw_chart_panel();
   // Pushes trade markers to the chart.
   void set_markers(const std::string &markers_json);
   // Draws/updates a price line for the currently open position.
@@ -96,6 +101,12 @@ private:
   std::function<void(const std::string &)> status_callback_;
   bool shutdown_called_ = false;
   mutable std::mutex ui_mutex_;
+
+  // Cached data for pair and interval selection combos
+  std::vector<std::string> pair_strings_;
+  std::vector<const char *> pair_items_;
+  std::vector<std::string> interval_strings_;
+  std::vector<const char *> interval_items_;
 
   // Throttling for real-time candle pushes
   std::chrono::steady_clock::time_point last_push_time_{};

--- a/tests/test_ui_manager.cpp
+++ b/tests/test_ui_manager.cpp
@@ -32,7 +32,9 @@ TEST(UiManager, MissingChartHtmlNotifies) {
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
-        ui.draw_chart_panel(pairs, intervals);
+        ui.set_pairs(pairs);
+        ui.set_intervals(intervals);
+        ui.draw_chart_panel();
 
         EXPECT_FALSE(msg.empty());
         EXPECT_NE(msg.find("chart"), std::string::npos);


### PR DESCRIPTION
## Summary
- cache trading pair and interval strings in UiManager
- expose `set_pairs` and `set_intervals` to rebuild cached arrays only when data changes
- use cached arrays in `draw_chart_panel`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cpr")*


------
https://chatgpt.com/codex/tasks/task_e_68ae2f2deec083279ef616e1e26179a8