### PR TITLE
Add optional verification flag to save_candles

### DIFF
--- a/src/core/candle_manager.h
+++ b/src/core/candle_manager.h
@@ -15,8 +15,9 @@ public:
     CandleManager();
     explicit CandleManager(const std::filesystem::path& dir);
 
-    // Saves a vector of candles to a CSV file.
-    bool save_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const;
+    // Saves a vector of candles to a CSV file. Optionally verifies the written data.
+    bool save_candles(const std::string& symbol, const std::string& interval,
+                      const std::vector<Candle>& candles, bool verify = true) const;
 
     // Appends new candles to an existing CSV file, skipping duplicates.
     bool append_candles(const std::string& symbol, const std::string& interval, const std::vector<Candle>& candles) const;


### PR DESCRIPTION
## Summary
- allow skipping post-save verification in `save_candles` via a new `verify` parameter
- flush written data and report file I/O errors before returning
- avoid internal deadlocks by computing paths outside of mutex-protected sections

## Testing
- `./test_candle_manager` *(fails: loaded.size() == 0, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae364304648327b836430d9d8b4abe