### PR TITLE
Refactor fetch_range request logic

### DIFF
--- a/src/services/data_service.h
+++ b/src/services/data_service.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <cstdint>
 #include <optional>
+#include <functional>
 
 #include "core/candle.h"
 #include "core/candle_manager.h"
@@ -79,6 +80,11 @@ public:
   const Core::CandleManager &candle_manager() const { return candle_manager_; }
 
 private:
+  Core::KlinesResult FetchRangeImpl(
+      const std::string &url,
+      const std::function<std::vector<Core::Candle>(const std::string &)> &parser,
+      int max_retries,
+      std::chrono::milliseconds retry_delay) const;
   const Config::ConfigData &config() const;
   std::shared_ptr<Core::IHttpClient> http_client_;
   std::shared_ptr<Core::IRateLimiter> rate_limiter_;


### PR DESCRIPTION
## Summary
- extract common range request/retry logic into private `FetchRangeImpl`
- simplify `fetch_range` to build provider URL and call the shared helper

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_68ae39549e048327b17130c960e4eaba