### PR TITLE
Simplify Journal::load_json error handling

### DIFF
--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -35,18 +35,12 @@ bool Journal::load_json(const std::string &filename) {
     }
     return true;
   }
-  if (!nlohmann::json::accept(content)) {
-    Core::Logger::instance().error("Invalid JSON format in journal file: " +
-                                   filename);
-    return false;
-  }
-
   nlohmann::json j;
   try {
     j = nlohmann::json::parse(content);
   } catch (const std::exception &e) {
-    Core::Logger::instance().error("Journal parse error: " +
-                                   std::string(e.what()));
+    Core::Logger::instance().error("Invalid JSON format in journal file: " +
+                                   filename + ": " + e.what());
     return false;
   }
 


### PR DESCRIPTION
## Summary
- remove nlohmann::json::accept check when loading journal data
- guard nlohmann::json::parse with try/catch and log parse errors

## Testing
- `cmake -S . -B build -DBUILD_TRADING_TERMINAL=OFF`
- `cmake --build build` *(fails: undefined reference to DataService::DataService)*

------
https://chatgpt.com/codex/tasks/task_e_68aedeff3b4c832790054670be5ce87f