### PR TITLE
Fix RSI period check and add boundary test

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -79,12 +79,13 @@ int ema_signal(const std::vector<Core::Candle>& candles,
   double relative_strength_index(const std::vector<Core::Candle>& candles,
                                  std::size_t index,
                                  std::size_t period) {
-    if (period == 0 || index >= candles.size() || index < period) {
+    if (period == 0 || index >= candles.size() || index + 1 < period) {
         return 0.0;
     }
     double gain = 0.0;
     double loss = 0.0;
-    for (std::size_t i = index + 1 - period; i <= index; ++i) {
+    std::size_t start = index + 2 - period;
+    for (std::size_t i = start; i <= index; ++i) {
         double change = candles[i].close - candles[i - 1].close;
         if (change > 0) {
             gain += change;

--- a/tests/test_rsi_boundary.cpp
+++ b/tests/test_rsi_boundary.cpp
@@ -1,0 +1,14 @@
+#include "signal.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(RsiTest, HandlesBoundaryIndex) {
+    std::vector<Core::Candle> candles;
+    double closes[] = {1, 2, 3};
+    for (int i = 0; i < 3; ++i) {
+        candles.emplace_back(i, 0, 0, 0, closes[i], 0, 0, 0, 0, 0, 0, 0);
+    }
+    double rsi = Signal::relative_strength_index(candles, 2, 3);
+    EXPECT_NEAR(rsi, 100.0, 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- Allow RSI calculation when the candle index equals `period - 1` by adjusting the early-exit condition and loop start
- Add a test to ensure RSI works correctly at this boundary case

## Testing
- `g++ -std=c++17 tests/test_rsi_boundary.cpp src/signal.cpp -I src -pthread -lgtest -lgtest_main -o rsi_test && ./rsi_test`

------
https://chatgpt.com/codex/tasks/task_e_68aee79b95008327aaedbf7a851ff5ce