### PR TITLE
Use JSON double extraction for kline fields

### DIFF
--- a/src/core/data_fetcher.cpp
+++ b/src/core/data_fetcher.cpp
@@ -98,16 +98,16 @@ KlinesResult DataFetcher::fetch_klines_from_api(
             const auto &kline = *it;
             all_candles.push_back(Candle(
                 kline[0].get<long long>(),
-                std::stod(kline[1].get<std::string>()),
-                std::stod(kline[2].get<std::string>()),
-                std::stod(kline[3].get<std::string>()),
-                std::stod(kline[4].get<std::string>()),
-                std::stod(kline[5].get<std::string>()),
+                kline[1].get<double>(),
+                kline[2].get<double>(),
+                kline[3].get<double>(),
+                kline[4].get<double>(),
+                kline[5].get<double>(),
                 kline[6].get<long long>(),
-                std::stod(kline[7].get<std::string>()), kline[8].get<int>(),
-                std::stod(kline[9].get<std::string>()),
-                std::stod(kline[10].get<std::string>()),
-                std::stod(kline[11].get<std::string>())));
+                kline[7].get<double>(), kline[8].get<int>(),
+                kline[9].get<double>(),
+                kline[10].get<double>(),
+                kline[11].get<double>()));
           }
           end_time = json_data.front()[0].get<long long>() - 1;
           success = true;

--- a/src/core/kline_stream.cpp
+++ b/src/core/kline_stream.cpp
@@ -76,14 +76,14 @@ void KlineStream::run(CandleCallback cb, ErrorCallback err_cb,
           bool closed = k.value("x", false);
           if (closed) {
             Candle c(
-                k.value("t", 0LL), std::stod(k.value("o", std::string("0"))),
-                std::stod(k.value("h", std::string("0"))),
-                std::stod(k.value("l", std::string("0"))),
-                std::stod(k.value("c", std::string("0"))),
-                std::stod(k.value("v", std::string("0"))), k.value("T", 0LL),
-                std::stod(k.value("q", std::string("0"))), k.value("n", 0),
-                std::stod(k.value("V", std::string("0"))),
-                std::stod(k.value("Q", std::string("0"))), 0.0);
+                k.value("t", 0LL), k.value("o", 0.0),
+                k.value("h", 0.0),
+                k.value("l", 0.0),
+                k.value("c", 0.0),
+                k.value("v", 0.0), k.value("T", 0LL),
+                k.value("q", 0.0), k.value("n", 0),
+                k.value("V", 0.0),
+                k.value("Q", 0.0), 0.0);
             candle_manager_.append_candles(symbol_, interval_, {c});
             if (cb)
               cb(c);


### PR DESCRIPTION
## Summary
- Use `json::get<double>` when parsing numeric kline fields to avoid string conversions
- Simplify kline stream parsing by pulling numeric values directly from JSON

## Testing
- `cmake --build build --target test_candle_manager test_interval_utils test_kline_stream test_scheduler test_logger test_signal test_ui_manager`
- `./test_interval_utils`
- `./test_kline_stream` *(fails: Fatal glibc error: tpp.c:83 assertion failed)*
- `./test_scheduler`
- `./test_logger`
- `./test_signal`
- `./test_ui_manager` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68af129b5938832783c765a2587d3cc0