### PR TITLE
Validate signal period parameters

### DIFF
--- a/src/services/signal_bot.cpp
+++ b/src/services/signal_bot.cpp
@@ -1,4 +1,5 @@
 #include "services/signal_bot.h"
+#include <cmath>
 
 SignalBot::SignalBot(const Config::SignalConfig& cfg) : cfg_(cfg) {}
 
@@ -18,7 +19,13 @@ int SignalBot::generate_signal(const std::vector<Core::Candle>& candles, size_t 
         if (period == 0) {
             auto it = cfg_.params.find("period");
             if (it != cfg_.params.end()) {
-                period = static_cast<std::size_t>(it->second);
+                double val = it->second;
+                if (val >= 0 && std::floor(val) == val) {
+                    period = static_cast<std::size_t>(val);
+                } else {
+                    Core::Logger::instance().warn("Invalid EMA period value");
+                    return 0;
+                }
             }
         }
         return Signal::ema_signal(candles, index, period);
@@ -27,7 +34,13 @@ int SignalBot::generate_signal(const std::vector<Core::Candle>& candles, size_t 
         if (period == 0) {
             auto it = cfg_.params.find("period");
             if (it != cfg_.params.end()) {
-                period = static_cast<std::size_t>(it->second);
+                double val = it->second;
+                if (val >= 0 && std::floor(val) == val) {
+                    period = static_cast<std::size_t>(val);
+                } else {
+                    Core::Logger::instance().warn("Invalid RSI period value");
+                    return 0;
+                }
             }
         }
         double oversold = 30.0;

--- a/tests/test_signal.cpp
+++ b/tests/test_signal.cpp
@@ -114,3 +114,31 @@ TEST(SignalIndicators, CalculatesMacd) {
     EXPECT_NEAR(m.histogram, 0.0, 1e-6);
 }
 
+TEST(SignalBotTest, ReturnsNeutralSignalOnInvalidEmaPeriod) {
+    std::vector<Core::Candle> candles;
+    for (int i = 0; i < 5; ++i) {
+        candles.emplace_back(i,0,0,0,static_cast<double>(i+1),0,0,0,0,0,0,0);
+    }
+    Config::SignalConfig cfg{"ema", 0, 0};
+    cfg.params["period"] = -5.0; // negative value
+    SignalBot bot(cfg);
+    EXPECT_EQ(bot.generate_signal(candles,4), 0);
+    cfg.params["period"] = 5.5; // non-integer value
+    bot.set_config(cfg);
+    EXPECT_EQ(bot.generate_signal(candles,4), 0);
+}
+
+TEST(SignalBotTest, ReturnsNeutralSignalOnInvalidRsiPeriod) {
+    std::vector<Core::Candle> candles;
+    for (int i = 0; i < 5; ++i) {
+        candles.emplace_back(i,0,0,0,static_cast<double>(i+1),0,0,0,0,0,0,0);
+    }
+    Config::SignalConfig cfg{"rsi", 0, 0};
+    cfg.params["period"] = -4.0; // negative value
+    SignalBot bot(cfg);
+    EXPECT_EQ(bot.generate_signal(candles,4), 0);
+    cfg.params["period"] = 3.2; // non-integer value
+    bot.set_config(cfg);
+    EXPECT_EQ(bot.generate_signal(candles,4), 0);
+}
+


### PR DESCRIPTION
## Summary
- Validate period values for EMA and RSI signals to avoid invalid casts
- Add tests covering negative and non-integer period values

## Testing
- `ctest -R test_signal --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68af175a8c948327888aae8aacc63305