### PR TITLE
Refactor KlineStream for safe shared ownership

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -381,7 +381,7 @@ void App::start_initial_fetch_and_streams() {
       this->ctx_->active_interval != "15s") {
     for (const auto &p : this->ctx_->pairs) {
       std::string pair = p.name;
-      auto stream = std::make_unique<Core::KlineStream>(
+      auto stream = std::make_shared<Core::KlineStream>(
           pair, this->ctx_->active_interval, data_service_.candle_manager());
       stream->start(
           [this, pair](const Core::Candle &c) {

--- a/src/app_context.h
+++ b/src/app_context.h
@@ -31,7 +31,7 @@ struct AppContext {
   std::map<std::string, std::map<std::string, std::vector<Core::Candle>>>
       all_candles;
   std::shared_mutex candles_mutex;
-  std::map<std::string, std::unique_ptr<Core::KlineStream>> streams;
+  std::map<std::string, std::shared_ptr<Core::KlineStream>> streams;
   std::atomic<bool> stream_failed{false};
   struct PendingFetch {
     std::string interval;

--- a/src/core/kline_stream.h
+++ b/src/core/kline_stream.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <condition_variable>
 #include <string>
 #include <thread>
 
@@ -13,7 +14,7 @@
 #include "iwebsocket.h"
 
 namespace Core {
-class KlineStream {
+class KlineStream : public std::enable_shared_from_this<KlineStream> {
 public:
   using CandleCallback = std::function<void(const Candle &)>;
   using ErrorCallback = std::function<void()>;
@@ -46,5 +47,8 @@ private:
   std::atomic<bool> running_{false};
   std::mutex ws_mutex_;
   std::unique_ptr<IWebSocket> ws_;
+  std::atomic<int> callbacks_inflight_{0};
+  std::mutex cb_mutex_;
+  std::condition_variable cb_cv_;
 };
 } // namespace Core


### PR DESCRIPTION
## Summary
- derive `KlineStream` from `std::enable_shared_from_this`
- guard WebSocket callbacks with `std::weak_ptr`
- wait for pending callbacks to finish in `stop()`
- switch stream storage to `std::shared_ptr`

## Testing
- `cmake --build build --target test_kline_stream`
- `ctest --test-dir build -R test_kline_stream --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68af1e578c4c8327836f0fa0986edb0d